### PR TITLE
Update SSH setup, switch OpenTofu to Homebrew, and add tui-glamorous skill docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ _audit/
 # Local reference repos
 _reference/
 
+skills/.SKILLS_MANAGED_BY_JSM
+
 # Local compiled tools
 bin/browser-tools
 scripts/node_modules/

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The `setup-ssh-from-1password.sh` script manages SSH configuration with security
 #### Default (Safe) Mode
 
 ```bash
-# Download SSH config + public keys only (private keys stay in 1Password)
+# Download base SSH config + per-profile fragment + public keys only
 ./setup-ssh-from-1password.sh
 
 # Check what's available without downloading
@@ -190,7 +190,8 @@ The `setup-ssh-from-1password.sh` script manages SSH configuration with security
 
 In safe mode:
 
-- Downloads SSH config from 1Password (stored as Secure Note)
+- Downloads base SSH config from 1Password (stored as Secure Note)
+- Downloads a per-profile SSH config fragment from 1Password
 - Downloads **public keys only** for reference
 - Private keys remain in 1Password
 - Uses 1Password SSH Agent for authentication
@@ -252,19 +253,40 @@ This approach:
 
 1. Open 1Password and create new item → SSH Key
 2. Name it exactly as expected by the script:
-   - `github_personal_authentication`
-   - `github_personal_signing`
-   - `aws_work_2024_client_1`
-   - `github_work_2025_client_1`
+   - `personal_github_authentication`
+   - `personal_github_signing`
+   - `work_2024_client_1_aws`
+   - `work_2025_client_1_github`
+   - `work_2025_client_2_github`
+   - `work_2025_client_2_ado`
 3. Paste your private key
-4. Save to "Private" vault (or adjust `VAULT` in script)
+4. Save to the vault expected by the script for that key
 
 #### SSH Config
 
 1. Create new item → Secure Note
-2. Name it: `SSH Config`
-3. Paste your complete SSH configuration
-4. Save to "Private" vault
+2. Name it: `~/.ssh/config`
+3. Add your base SSH configuration, for example:
+
+   ```sshconfig
+   Host *
+     IdentityAgent "~/.1password/agent.sock"
+
+   Include ~/.ssh/config.d/*.conf
+   ```
+
+4. Save it in the vault selected by `SSH_CONFIG_VAULT` or `VAULT`
+
+#### SSH Config Fragments
+
+1. Create new item → Secure Note
+2. Name it as one of:
+   - `~/.ssh/config.d/personal.conf`
+   - `~/.ssh/config.d/work-2024-client-1.conf`
+   - `~/.ssh/config.d/work-2025-client-1.conf`
+   - `~/.ssh/config.d/work-2025-client-2.conf`
+3. Add only the host stanzas for that profile
+4. Save it in the same vault as that profile's SSH keys
 
 #### Git Config
 
@@ -275,6 +297,11 @@ This approach:
    ```ini
    [url "github-work:OrgName/"]
      insteadOf = git@github.com:OrgName/
+     insteadOf = https://github.com/OrgName/
+
+   [url "git@ado-work-2025-client-2:v3/ORG/PROJECT/"]
+     insteadOf = git@ssh.dev.azure.com:v3/ORG/PROJECT/
+
    [user]
      email = work@company.com
    ```

--- a/_configs/focus/infrastructure.yaml
+++ b/_configs/focus/infrastructure.yaml
@@ -17,9 +17,9 @@ tools:
     documentation_url: "https://terraform.io"
     category: infrastructure
 
-  tofu:
-    manager: arkade
-    type: get
+  opentofu:
+    manager: brew
+    type: package
     check_command: command -v tofu
     description: "Open-source Terraform fork"
     documentation_url: "https://opentofu.org/"

--- a/_test/1password.bats
+++ b/_test/1password.bats
@@ -73,14 +73,24 @@ if [[ "$1" == "item" ]] && [[ "$2" == "get" ]]; then
         cat <<'CONFIG'
 Host *
   IdentityAgent "~/.1password/agent.sock"
-
-Host github-work
-    HostName github.com
-    User git
-    IdentityFile ~/.ssh/work_key.pub
+Include ~/.ssh/config.d/*.conf
 CONFIG
       else
         echo "~/.ssh/config found"
+      fi
+      exit 0
+      ;;
+    "~/.ssh/config.d/personal.conf")
+      if [[ "$@" == *"--fields"* ]] && [[ "$@" == *"notes"* ]]; then
+        cat <<'CONFIG'
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/personal_github_authentication.pub
+  IdentitiesOnly yes
+CONFIG
+      else
+        echo "~/.ssh/config.d/personal.conf found"
       fi
       exit 0
       ;;
@@ -89,6 +99,10 @@ CONFIG
         cat <<'GITCONFIG'
 [url "github-work:OrgName/"]
   insteadOf = git@github.com:OrgName/
+  insteadOf = https://github.com/OrgName/
+
+[url "git@ado-work-2025-client-2:v3/ORG/PROJECT/"]
+  insteadOf = git@ssh.dev.azure.com:v3/ORG/PROJECT/
 
 [user]
   email = work@example.com
@@ -98,7 +112,7 @@ GITCONFIG
       fi
       exit 0
       ;;
-    "personal_github_authentication"|"personal_github_signing"|"work_aws_2024_client_1"|"work_github_2025_client_1")
+    "personal_github_authentication"|"personal_github_signing"|"work_2024_client_1_aws"|"work_2025_client_1_github")
       echo "$item_name found"
       exit 0
       ;;
@@ -132,7 +146,8 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"SSH Config Dry Run"* ]]
   [[ "$output" == *"Found in 1Password:"* ]]
-  [[ "$output" == *"~/.ssh/config (Secure Note)"* ]]
+  [[ "$output" == *"~/.ssh/config (Secure Note, vault: Private)"* ]]
+  [[ "$output" == *"~/.ssh/config.d/personal.conf"* ]]
   [[ "$output" == *"personal_github_authentication"* ]]
   [[ "$output" == *"No files were modified"* ]]
 }
@@ -152,9 +167,19 @@ if [[ "$1" == "account" ]] && [[ "$2" == "list" ]]; then
 fi
 
 if [[ "$1" == "item" ]] && [[ "$2" == "get" ]]; then
-  if [[ "$@" == *"--fields notes"* ]]; then
+  if [[ "$3" == "~/.ssh/config" ]] && [[ "$@" == *"--fields notes"* ]]; then
     echo "Host *"
     echo "  IdentityAgent ~/.1password/agent.sock"
+    echo "Include ~/.ssh/config.d/*.conf"
+    exit 0
+  fi
+
+  if [[ "$3" == "~/.ssh/config.d/personal.conf" ]] && [[ "$@" == *"--fields notes"* ]]; then
+    echo "Host github.com"
+    echo "  HostName github.com"
+    echo "  User git"
+    echo "  IdentityFile ~/.ssh/personal_github_authentication.pub"
+    echo "  IdentitiesOnly yes"
     exit 0
   fi
 
@@ -179,6 +204,9 @@ EOF
   grep -q "public key" "$TEST_DIR/op-calls.log"
   run grep -q "private key" "$TEST_DIR/op-calls.log"
   [ "$status" -ne 0 ]
+  [ -f "$HOME/.ssh/config.d/personal.conf" ]
+  run grep -q "Host github.com" "$HOME/.ssh/config.d/personal.conf"
+  [ "$status" -eq 0 ]
 }
 
 @test "SSH setup: unsafe mode requires confirmation" {

--- a/_test/shell-configs.bats
+++ b/_test/shell-configs.bats
@@ -181,6 +181,20 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+@test "zshrc: prepends docker completions directory to fpath when present" {
+  mkdir -p "$HOME/.docker/completions"
+  touch "$HOME/.docker/completions/_docker"
+
+  result=$(/bin/zsh -c "
+    export HOME='$HOME'
+    export DOTFILES_DIR='$DOTFILES_DIR'
+    source $DOTFILES_DIR/zsh/.zshrc 2>/dev/null
+    print -r -- \$fpath[1]
+  ")
+
+  [ "$result" = "$HOME/.docker/completions" ]
+}
+
 @test "zshrc: direnv only initialized when direnv exists" {
   # Test without direnv - should not error
   run zsh -c "
@@ -276,11 +290,18 @@ EOF
     skip "No suitable 'time' command with -p flag available"
   fi
 
+  local zdotdir="$HOME/zdotdir"
+  mkdir -p "$zdotdir"
+  ln -sf "$DOTFILES_DIR/zsh/.zshrc" "$zdotdir/.zshrc"
+  if [ -f "$DOTFILES_DIR/zsh/.zshenv" ]; then
+    ln -sf "$DOTFILES_DIR/zsh/.zshenv" "$zdotdir/.zshenv"
+  fi
+
   local -a zsh_cmd=(
     env
     HOME="$HOME"
     DOTFILES_DIR="$DOTFILES_DIR"
-    ZDOTDIR="$DOTFILES_DIR/zsh"
+    ZDOTDIR="$zdotdir"
     TERM="xterm-256color"
     zsh -i -c exit
   )

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "opus[1m]",
   "statusLine": {
     "type": "command",
     "command": "bash -c 'input=$(cat); cwd=$(echo \"$input\" | jq -r \".workspace.current_dir // .cwd\"); display_dir=\"${cwd/#$HOME/\\~}\"; printf \"\\033[38;5;85m\\033[1m%s\\033[0m\" \"$display_dir\"; if git -C \"$cwd\" rev-parse --git-dir >/dev/null 2>&1; then branch=$(git -C \"$cwd\" --no-optional-locks branch --show-current 2>/dev/null || echo \"detached\"); printf \" \\033[1mgit\\033[0m \\033[0;32m\\033[1m%s\\033[0m\" \"$branch\"; status=$(git -C \"$cwd\" --no-optional-locks status --porcelain 2>/dev/null); if [ -n \"$status\" ]; then modified=$(echo \"$status\" | grep -c \"^ M\" || true); untracked=$(echo \"$status\" | grep -c \"^??\" || true); staged=$(echo \"$status\" | grep -c \"^M\" || true); status_info=\"\"; [ \"$staged\" -gt 0 ] && status_info+=\"$(printf \"\\033[0;32m✓%s\\033[0m \" \"$staged\")\"; [ \"$modified\" -gt 0 ] && status_info+=\"$(printf \"\\033[0;34m!%s\\033[0m \" \"$modified\")\"; [ \"$untracked\" -gt 0 ] && status_info+=\"$(printf \"\\033[0;36m?%s\\033[0m \" \"$untracked\")\"; [ -n \"$status_info\" ] && printf \" %s\" \"$status_info\"; fi; fi; if [ -f \"$cwd/package.json\" ] && command -v node >/dev/null 2>&1; then node_version=$(node --version 2>/dev/null | sed \"s/v//\"); printf \" \\033[0;32m\\033[1m󰎙 %s\\033[0m\" \"$node_version\"; fi; if ls \"$cwd\"/*.tf >/dev/null 2>&1; then printf \" \\033[1mterraform\\033[0m\"; fi; current_time=$(date \"+%H:%M\"); printf \" [%s]\" \"$current_time\"; echo'"
@@ -8,6 +9,5 @@
     "frontend-design@claude-code-plugins": true,
     "pr-review-toolkit@claude-code-plugins": true
   },
-  "alwaysThinkingEnabled": true,
-  "model": "opus"
+  "alwaysThinkingEnabled": true
 }

--- a/setup-gitconfig-from-1password.sh
+++ b/setup-gitconfig-from-1password.sh
@@ -283,6 +283,8 @@ if [ ${#failed_configs[@]} -gt 0 ]; then
   echo '  [url "github-work-alias:OrgName/"]'
   echo '    insteadOf = git@github.com:OrgName/'
   echo '    insteadOf = https://github.com/OrgName/'
+  echo '  [url "git@ado-work-2025-client-2:v3/ORG/PROJECT/"]'
+  echo '    insteadOf = git@ssh.dev.azure.com:v3/ORG/PROJECT/'
   echo '  [user]'
   echo '    email = first.last@company.com'
 fi

--- a/setup-ssh-from-1password.sh
+++ b/setup-ssh-from-1password.sh
@@ -13,7 +13,7 @@ UNSAFE_MODE="${UNSAFE_MODE:-false}"
 MACHINE_PROFILE="${MACHINE_PROFILE:-}"
 FORCE_OVERWRITE="${FORCE_OVERWRITE:-false}"
 LITERAL_TILDE='~'
-SSH_CONFIG_ITEM_NAME="${LITERAL_TILDE}/.ssh/config"
+SSH_CONFIG_BASE_ITEM_NAME="${LITERAL_TILDE}/.ssh/config"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -42,7 +42,8 @@ usage() {
   echo "  work-2025-client-2  - Work 2025 Client 2 GitHub + Azure DevOps keys"
   echo ""
   echo "Default behavior:"
-  echo "  - Downloads SSH config from 1Password"
+  echo "  - Downloads base SSH config from 1Password"
+  echo "  - Downloads a per-profile SSH config fragment from 1Password"
   echo "  - Downloads public keys only (private keys stay in 1Password)"
   echo "  - Uses 1Password SSH Agent for authentication"
   echo "  - Prompts for machine profile if not specified"
@@ -113,11 +114,22 @@ if ! op account list >/dev/null 2>&1; then
 fi
 
 # Configuration
-readonly VAULT="${VAULT:-Private}" # Vault name is now configurable, defaults to "Private"
+readonly DEFAULT_VAULT="${VAULT:-Private}" # Backward-compatible default
+readonly SSH_CONFIG_VAULT="${SSH_CONFIG_VAULT:-$DEFAULT_VAULT}"
 readonly SSH_DIR="$HOME/.ssh"
+readonly SSH_CONFIG_DIR="$SSH_DIR/config.d"
 declare BACKUP_DIR
 BACKUP_DIR="$SSH_DIR/backups/$(date +%Y%m%d-%H%M%S)"
 readonly BACKUP_DIR
+
+# Per-profile SSH config fragments
+# Format: "profile:1password_item_name:local_filename:vault_name"
+declare -a ALL_SSH_CONFIG_FRAGMENTS=(
+  "personal:${LITERAL_TILDE}/.ssh/config.d/personal.conf:personal.conf:Private"
+  "work-2024-client-1:${LITERAL_TILDE}/.ssh/config.d/work-2024-client-1.conf:work-2024-client-1.conf:Work 2024 Client 1"
+  "work-2025-client-1:${LITERAL_TILDE}/.ssh/config.d/work-2025-client-1.conf:work-2025-client-1.conf:Work 2025 Client 1"
+  "work-2025-client-2:${LITERAL_TILDE}/.ssh/config.d/work-2025-client-2.conf:work-2025-client-2.conf:Work 2025 Client 2"
+)
 
 # All available SSH keys in 1Password
 # Format: "1password_item_name:local_filename:vault_name"
@@ -214,9 +226,49 @@ for key_mapping in "${ALL_SSH_KEYS[@]}"; do
   fi
 done
 
+# Filter SSH config fragments based on selected machine profile
+declare -a SSH_CONFIG_FRAGMENTS=()
+
+for fragment_mapping in "${ALL_SSH_CONFIG_FRAGMENTS[@]}"; do
+  IFS=':' read -r fragment_profile op_name local_name item_vault <<<"$fragment_mapping"
+
+  if [[ "$fragment_profile" == "$MACHINE_PROFILE" ]]; then
+    SSH_CONFIG_FRAGMENTS+=("$fragment_mapping")
+  fi
+done
+
 info "Machine profile: $MACHINE_PROFILE"
+info "Will download ${#SSH_CONFIG_FRAGMENTS[@]} SSH config fragment(s) for this profile"
 info "Will download ${#SSH_KEYS[@]} SSH key(s) for this profile"
 echo
+
+sanitize_downloaded_note() {
+  local file="$1"
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' 's/^"//; s/"$//; s/""/"/g' "$file"
+  else
+    sed -i 's/^"//; s/"$//; s/""/"/g' "$file"
+  fi
+}
+
+download_secure_note() {
+  local item_name="$1"
+  local item_vault="$2"
+  local destination="$3"
+
+  if op item get "$item_name" --vault="$item_vault" --fields notesPlain 2>/dev/null >"$destination" ||
+     op item get "$item_name" --vault="$item_vault" --fields notes 2>/dev/null >"$destination"; then
+    if [[ -s "$destination" ]]; then
+      sanitize_downloaded_note "$destination"
+      chmod 600 "$destination"
+      return 0
+    fi
+  fi
+
+  rm -f "$destination"
+  return 1
+}
 
 # Dry run mode - just check what's available
 if [[ "$DRY_RUN" == "true" ]]; then
@@ -231,18 +283,30 @@ if [[ "$DRY_RUN" == "true" ]]; then
   available_items=()
   missing_items=()
 
-  # Check SSH Config
-  if op item get "$SSH_CONFIG_ITEM_NAME" --vault="$VAULT" >/dev/null 2>&1; then
-    available_items+=("$SSH_CONFIG_ITEM_NAME (Secure Note)")
+  # Check base SSH config
+  if op item get "$SSH_CONFIG_BASE_ITEM_NAME" --vault="$SSH_CONFIG_VAULT" >/dev/null 2>&1; then
+    available_items+=("$SSH_CONFIG_BASE_ITEM_NAME (Secure Note, vault: $SSH_CONFIG_VAULT)")
   else
-    missing_items+=("$SSH_CONFIG_ITEM_NAME (Secure Note)")
+    missing_items+=("$SSH_CONFIG_BASE_ITEM_NAME (Secure Note, vault: $SSH_CONFIG_VAULT)")
   fi
+
+  # Check SSH config fragments
+  for fragment_mapping in "${SSH_CONFIG_FRAGMENTS[@]}"; do
+    IFS=':' read -r fragment_profile op_name local_name item_vault <<<"$fragment_mapping"
+    item_vault="${item_vault:-$DEFAULT_VAULT}"
+
+    if op item get "$op_name" --vault="$item_vault" >/dev/null 2>&1; then
+      available_items+=("$op_name → $local_name (vault: $item_vault)")
+    else
+      missing_items+=("$op_name → $local_name (vault: $item_vault)")
+    fi
+  done
 
   # Check SSH Keys
   for key_mapping in "${SSH_KEYS[@]}"; do
     IFS=':' read -r op_name local_name item_vault <<<"$key_mapping"
     # Use specified vault or fall back to default
-    item_vault="${item_vault:-$VAULT}"
+    item_vault="${item_vault:-$DEFAULT_VAULT}"
 
     if op item get "$op_name" --vault="$item_vault" >/dev/null 2>&1; then
       available_items+=("$op_name → $local_name (vault: $item_vault)")
@@ -266,7 +330,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
     done
     echo
     echo "To add missing items:"
-    echo "  • SSH Config: Create a Secure Note named '~/.ssh/config'"
+    echo "  • Base SSH config: Create a Secure Note named '~/.ssh/config'"
+    echo "  • Per-profile config: Create a Secure Note named '~/.ssh/config.d/<profile>.conf'"
     echo "  • SSH Keys: Create SSH Key items with exact names shown above"
     echo "  • Save each item in the vault shown in parentheses"
   fi
@@ -327,6 +392,7 @@ if [[ "$UNSAFE_MODE" == "true" ]]; then
 fi
 
 # Create backup directory
+mkdir -p "$SSH_DIR" "$SSH_CONFIG_DIR"
 mkdir -p "$BACKUP_DIR"
 info "Created backup directory: $BACKUP_DIR"
 
@@ -343,47 +409,79 @@ backup_file() {
 info "Backing up existing SSH files..."
 backup_file "$SSH_DIR/config"
 
+for fragment_mapping in "${SSH_CONFIG_FRAGMENTS[@]}"; do
+  IFS=':' read -r fragment_profile op_name local_name item_vault <<<"$fragment_mapping"
+  backup_file "$SSH_CONFIG_DIR/$local_name"
+done
+
 for key_mapping in "${SSH_KEYS[@]}"; do
   IFS=':' read -r op_name local_name item_vault <<<"$key_mapping"
   backup_file "$SSH_DIR/$local_name"
   backup_file "$SSH_DIR/${local_name}.pub"
 done
 
-# Step 2: Setup SSH Config (from 1Password or example)
-info "Setting up SSH config..."
-# Try notesPlain first (Secure Notes), then notes (older format)
-if op item get "$SSH_CONFIG_ITEM_NAME" --vault="$VAULT" --fields notesPlain 2>/dev/null >"$SSH_DIR/config" ||
-   op item get "$SSH_CONFIG_ITEM_NAME" --vault="$VAULT" --fields notes 2>/dev/null >"$SSH_DIR/config"; then
-  # Remove surrounding quotes and fix escaped quotes (1Password CLI adds them)
-  # First remove outer quotes from entire file, then fix doubled quotes
-  # Detect platform for sed in-place editing
-  if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' 's/^"//; s/"$//; s/""/"/g' "$SSH_DIR/config"
-  else
-    sed -i 's/^"//; s/"$//; s/""/"/g' "$SSH_DIR/config"
-  fi
-  chmod 600 "$SSH_DIR/config"
-  success "SSH config downloaded from 1Password and permissions set"
+# Step 2: Setup base SSH config (from 1Password or example)
+info "Setting up base SSH config..."
+if download_secure_note "$SSH_CONFIG_BASE_ITEM_NAME" "$SSH_CONFIG_VAULT" "$SSH_DIR/config"; then
+  success "Base SSH config downloaded from 1Password and permissions set"
 else
-  warning "SSH config not found in 1Password"
+  warning "Base SSH config not found in 1Password"
 
   # Check for config.example as fallback
   if [ -f "$SSH_DIR/config.example" ]; then
     info "Using config.example as template..."
     cp "$SSH_DIR/config.example" "$SSH_DIR/config"
     chmod 600 "$SSH_DIR/config"
-    success "SSH config created from example template"
-    echo "  Note: Update the config with your actual hosts and keys"
+    success "Base SSH config created from example template"
+    echo "  Note: Ensure it includes 'Include ~/.ssh/config.d/*.conf'"
   else
     warning "No config.example found either"
-    echo "  To add SSH config to 1Password:"
+    echo "  To add base SSH config to 1Password:"
     echo "  1. Create a Secure Note in 1Password called '~/.ssh/config'"
     echo "  2. Paste your SSH config content in the notes field"
-    echo "  3. Save in the '$VAULT' vault"
+    echo "  3. Save in the '$SSH_CONFIG_VAULT' vault"
   fi
 fi
 
-# Step 3: Download SSH Keys
+# Step 3: Setup per-profile SSH config fragments
+info "Setting up SSH config fragments..."
+if [[ "$FORCE_OVERWRITE" == "false" ]]; then
+  info "Skipping existing config fragments (use --force to overwrite)"
+fi
+echo
+
+failed_fragments=()
+successful_fragments=()
+skipped_fragments=()
+
+for fragment_mapping in "${SSH_CONFIG_FRAGMENTS[@]}"; do
+  IFS=':' read -r fragment_profile op_name local_name item_vault <<<"$fragment_mapping"
+  item_vault="${item_vault:-$DEFAULT_VAULT}"
+
+  info "Processing $op_name (vault: $item_vault)..."
+
+  if [[ "$FORCE_OVERWRITE" == "false" ]] && [[ -f "$SSH_CONFIG_DIR/$local_name" ]]; then
+    info "  Skipping $local_name (already exists)"
+    skipped_fragments+=("$local_name (use --force to overwrite)")
+    continue
+  fi
+
+  if download_secure_note "$op_name" "$item_vault" "$SSH_CONFIG_DIR/$local_name"; then
+    successful_fragments+=("$local_name")
+    continue
+  fi
+
+  if [[ -f "$SSH_CONFIG_DIR/${local_name}.example" ]]; then
+    cp "$SSH_CONFIG_DIR/${local_name}.example" "$SSH_CONFIG_DIR/$local_name"
+    chmod 600 "$SSH_CONFIG_DIR/$local_name"
+    successful_fragments+=("$local_name (from example)")
+    warning "Used ${local_name}.example as fallback"
+  else
+    failed_fragments+=("$op_name → $local_name")
+  fi
+done
+
+# Step 4: Download SSH Keys
 if [[ "$UNSAFE_MODE" == "true" ]]; then
   info "Retrieving SSH keys from 1Password (PRIVATE + PUBLIC)..."
 else
@@ -402,7 +500,7 @@ skipped_keys=()
 for key_mapping in "${SSH_KEYS[@]}"; do
   IFS=':' read -r op_name local_name item_vault <<<"$key_mapping"
   # Use specified vault or fall back to default
-  item_vault="${item_vault:-$VAULT}"
+  item_vault="${item_vault:-$DEFAULT_VAULT}"
 
   info "Processing $op_name (vault: $item_vault)..."
 
@@ -495,7 +593,7 @@ for key_mapping in "${SSH_KEYS[@]}"; do
   fi
 done
 
-# Step 4: Verify SSH agent access
+# Step 5: Verify SSH agent access
 info "Checking SSH agent..."
 if [ -S "$HOME/.1password/agent.sock" ]; then
   success "1Password SSH agent is available"
@@ -504,11 +602,41 @@ else
   echo "  Enable it in 1Password Settings → Developer → SSH Agent"
 fi
 
-# Step 5: Report results
+# Step 6: Report results
 echo
 echo "========================================="
 echo "SSH Setup Summary"
 echo "========================================="
+
+if [ ${#successful_fragments[@]} -gt 0 ]; then
+  success "Successfully configured SSH fragments:"
+  for fragment in "${successful_fragments[@]}"; do
+    echo "  • $fragment"
+  done
+fi
+
+if [ ${#skipped_fragments[@]} -gt 0 ]; then
+  echo
+  info "Skipped existing SSH fragments:"
+  for fragment in "${skipped_fragments[@]}"; do
+    echo "  ↷ $fragment"
+  done
+fi
+
+if [ ${#failed_fragments[@]} -gt 0 ]; then
+  echo
+  warning "Failed to download SSH fragments:"
+  for fragment in "${failed_fragments[@]}"; do
+    echo "  ✗ $fragment"
+  done
+  echo
+  echo "To add SSH config fragments to 1Password:"
+  echo "  1. Open 1Password"
+  echo "  2. Create new item → Secure Note"
+  echo "  3. Name it exactly as shown above (before the →)"
+  echo "  4. Paste your SSH host stanzas in the notes field"
+  echo "  5. Save in the vault shown in the error message"
+fi
 
 if [ ${#successful_keys[@]} -gt 0 ]; then
   success "Successfully downloaded keys:"
@@ -540,12 +668,13 @@ if [ ${#failed_keys[@]} -gt 0 ]; then
   echo "  5. Save in the vault shown in the error message"
 fi
 
-# Step 6: Test SSH connections
+# Step 7: Test SSH connections
 echo
 info "Testing SSH connections..."
 echo "You can test your connections with:"
 echo "  ssh -T git@github.com"
-echo "  ssh -T git@github-work"
+echo "  ssh -T git@github-work-2025-client-1"
+echo "  ssh -T git@ado-work-2025-client-2"
 
 echo
 success "SSH setup complete!"

--- a/ssh/.ssh/config.d/personal.conf.example
+++ b/ssh/.ssh/config.d/personal.conf.example
@@ -1,0 +1,6 @@
+# Personal GitHub
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/personal_github_authentication.pub
+  IdentitiesOnly yes

--- a/ssh/.ssh/config.d/work-2024-client-1.conf.example
+++ b/ssh/.ssh/config.d/work-2024-client-1.conf.example
@@ -1,0 +1,6 @@
+# Work 2024 Client 1
+Host aws-work-2024-client-1
+  HostName example.compute.amazonaws.com
+  User ubuntu
+  IdentityFile ~/.ssh/work_2024_client_1_aws.pem
+  IdentitiesOnly yes

--- a/ssh/.ssh/config.d/work-2025-client-1.conf.example
+++ b/ssh/.ssh/config.d/work-2025-client-1.conf.example
@@ -1,0 +1,6 @@
+# Work 2025 Client 1
+Host github-work-2025-client-1
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/work_2025_client_1_github.pub
+  IdentitiesOnly yes

--- a/ssh/.ssh/config.d/work-2025-client-2.conf.example
+++ b/ssh/.ssh/config.d/work-2025-client-2.conf.example
@@ -1,0 +1,14 @@
+# Work 2025 Client 2
+Host github-work-2025-client-2
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/work_2025_client_2_github.pub
+  IdentitiesOnly yes
+
+Host ado-work-2025-client-2
+  HostName ssh.dev.azure.com
+  User git
+  IdentityFile ~/.ssh/work_2025_client_2_ado.pub
+  IdentitiesOnly yes
+  # Optional: silence OpenSSH's post-quantum warning for this host.
+  # WarnWeakCrypto no-pq-kex

--- a/ssh/.ssh/config.example
+++ b/ssh/.ssh/config.example
@@ -1,24 +1,6 @@
-# Based off the creation of a symlink as per https://developer.1password.com/docs/ssh/get-started/#step-4-configure-your-ssh-or-git-client
+# Base SSH config.
+# Keep machine-wide defaults here and put host-specific entries in ~/.ssh/config.d/*.conf.
 Host *
   IdentityAgent "~/.1password/agent.sock"
 
-Host example
-    HostName example.com
-    User myuser
-    Port 22
-    IdentityFile ~/.ssh/id_example
-
-# As per https://developer.1password.com/docs/ssh/agent/advanced
-# Personal GitHub
-Host github-personal
-	HostName github.com
-	User git
-	IdentityFile ~/.ssh/personal_git.pub
-	IdentitiesOnly yes
-
-# Work GitHub, under an Enterprise Org
-Host github-work-org
-	HostName github.com
-	User git
-	IdentityFile ~/.ssh/work_git.pub
-	IdentitiesOnly yes
+Include ~/.ssh/config.d/*.conf

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -7,7 +7,12 @@ Template and management scripts for secure SSH configuration using 1Password as 
 ```text
 ssh/
 └── .ssh/
-    └── config.example  # Template SSH config with 1Password agent setup
+    ├── config.example
+    └── config.d/
+        ├── personal.conf.example
+        ├── work-2024-client-1.conf.example
+        ├── work-2025-client-1.conf.example
+        └── work-2025-client-2.conf.example
 ```
 
 ## Why This Approach?
@@ -25,7 +30,8 @@ The setup script manages SSH configuration with security in mind:
 
 ### Default (Safe) Mode
 
-- Downloads SSH config from 1Password (Secure Note)
+- Downloads base SSH config from 1Password (Secure Note)
+- Downloads one per-profile SSH config fragment from 1Password
 - Downloads **public keys only** for reference
 - Private keys remain in 1Password
 - Uses 1Password SSH Agent for authentication
@@ -41,18 +47,24 @@ The setup script manages SSH configuration with security in mind:
 
 | 1Password Item                     | Safe Mode (Default)                  | Unsafe Mode                          | Purpose                          |
 | ---------------------------------- | ------------------------------------ | ------------------------------------ | -------------------------------- |
-| `~/.ssh/config` (Secure Note)      | `~/.ssh/config`                      | `~/.ssh/config`                      | Complete SSH configuration       |
+| `~/.ssh/config` (Secure Note)      | `~/.ssh/config`                      | `~/.ssh/config`                      | Base SSH configuration           |
+| `~/.ssh/config.d/personal.conf`    | `~/.ssh/config.d/personal.conf`      | `~/.ssh/config.d/personal.conf`      | Personal host stanzas            |
+| `~/.ssh/config.d/work-2024-client-1.conf` | `~/.ssh/config.d/work-2024-client-1.conf` | `~/.ssh/config.d/work-2024-client-1.conf` | Client 1 host stanzas     |
+| `~/.ssh/config.d/work-2025-client-1.conf` | `~/.ssh/config.d/work-2025-client-1.conf` | `~/.ssh/config.d/work-2025-client-1.conf` | Client 1 host stanzas     |
+| `~/.ssh/config.d/work-2025-client-2.conf` | `~/.ssh/config.d/work-2025-client-2.conf` | `~/.ssh/config.d/work-2025-client-2.conf` | Client 2 host stanzas     |
 | `personal_github_authentication`   | `~/.ssh/personal_github_authentication.pub` | `~/.ssh/personal_github_authentication` + `.pub` | Personal GitHub authentication   |
 | `personal_github_signing`          | `~/.ssh/personal_github_signing.pub` | `~/.ssh/personal_github_signing` + `.pub` | GitHub commit signing       |
 | `work_2024_client_1_aws`           | `~/.ssh/work_2024_client_1_aws.pem.pub` | `~/.ssh/work_2024_client_1_aws.pem` + `.pub` | AWS EC2 access        |
 | `work_2025_client_1_github`        | `~/.ssh/work_2025_client_1_github.pub` | `~/.ssh/work_2025_client_1_github` + `.pub` | Work GitHub access      |
+| `work_2025_client_2_github`        | `~/.ssh/work_2025_client_2_github.pub` | `~/.ssh/work_2025_client_2_github` + `.pub` | Work GitHub access      |
+| `work_2025_client_2_ado`           | `~/.ssh/work_2025_client_2_ado.pub` | `~/.ssh/work_2025_client_2_ado` + `.pub` | Azure DevOps access     |
 
 ### Running Setup
 
 The setup script `setup-ssh-from-1password.sh` (in repository root) handles everything:
 
 ```bash
-# Safe mode (default) - config + public keys only
+# Safe mode (default) - base config + per-profile fragment + public keys only
 ./setup-ssh-from-1password.sh
 
 # Check what would be downloaded without making changes
@@ -67,12 +79,31 @@ The setup script `setup-ssh-from-1password.sh` (in repository root) handles ever
 
 ## 1Password Configuration
 
-### SSH Config (Secure Note)
+### Base SSH Config (Secure Note)
 
 1. Create a **Secure Note** in 1Password
 2. Name it: `~/.ssh/config`
-3. Paste your complete SSH configuration in the notes field
-4. Save to your vault (default: "Private")
+3. Add your machine-wide defaults, including:
+
+   ```sshconfig
+   Host *
+     IdentityAgent "~/.1password/agent.sock"
+
+   Include ~/.ssh/config.d/*.conf
+   ```
+
+4. Save it to the vault selected by `SSH_CONFIG_VAULT` or `VAULT`
+
+### Per-Profile SSH Config Fragments (Secure Notes)
+
+Create one Secure Note per profile and store it in the same vault as that profile's keys:
+
+- `~/.ssh/config.d/personal.conf`
+- `~/.ssh/config.d/work-2024-client-1.conf`
+- `~/.ssh/config.d/work-2025-client-1.conf`
+- `~/.ssh/config.d/work-2025-client-2.conf`
+
+The setup script downloads only the fragment for the selected profile and leaves the others in place, which makes multi-profile machines additive instead of overwrite-only.
 
 ### SSH Keys (SSH Key Items)
 
@@ -83,6 +114,33 @@ For each key:
 3. Paste the private key content
 4. 1Password automatically extracts the public key
 5. Tag appropriately for organization
+
+### Azure DevOps Setup
+
+Azure DevOps needs both sides configured:
+
+1. Create an SSH Key item in 1Password named `work_2025_client_2_ado`
+2. Add that item's public key to Azure DevOps at User settings -> SSH public keys
+3. Add a host stanza to `~/.ssh/config.d/work-2025-client-2.conf` that points `ssh.dev.azure.com` at `~/.ssh/work_2025_client_2_ado.pub`
+4. Run `./setup-ssh-from-1password.sh --profile work-2025-client-2` on the target machine
+
+Example host stanza:
+
+```sshconfig
+Host ado-work-2025-client-2
+  HostName ssh.dev.azure.com
+  User git
+  IdentityFile ~/.ssh/work_2025_client_2_ado.pub
+  IdentitiesOnly yes
+```
+
+Example clone URL using that alias:
+
+```bash
+git clone git@ado-work-2025-client-2:v3/ORG/PROJECT/REPO
+```
+
+If OpenSSH warns that the connection is not using a post-quantum key exchange algorithm when talking to `ssh.dev.azure.com`, that warning is about the server's key exchange support, not whether your uploaded key is valid.
 
 ## Security Notes
 
@@ -119,7 +177,10 @@ Ensure 1Password SSH Agent is enabled:
 ssh -T git@github.com
 
 # Work GitHub
-ssh -T git@github-work
+ssh -T git@github-work-2025-client-1
+
+# Azure DevOps
+ssh -T git@ado-work-2025-client-2
 
 # AWS instances (if configured)
 ssh <hostname>

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -10,7 +10,7 @@
 #   3. Homebrew          - Package manager setup + BREW_PREFIX cache
 #   4. Init Caching      - Cache tool init scripts for faster startup
 #   5. Key Bindings      - Word/line navigation, history search
-#   6. Completions       - compinit, Azure CLI, kubectl
+#   6. Completions       - compinit, Docker, Azure CLI, kubectl
 #   7. Tool Init         - Starship, rbenv, zoxide, fzf, uv
 #   8. Plugins           - zsh-autosuggestions, zsh-syntax-highlighting
 #   9. FNM               - Fast Node Manager
@@ -121,10 +121,20 @@ bindkey "^[[B" history-beginning-search-forward  # Down arrow
 #
 # 6. Completions
 #
+# Add user-managed completion directories before compinit runs.
+if [[ -d "$HOME/.docker/completions" ]]; then
+  fpath=("$HOME/.docker/completions" $fpath)
+fi
+
 # -Uz ensures that compinit is loaded as a pure function according
 #  to zsh's standards, without interference from any aliases defined.
 #  Then executes it with the -i flag to ignore insecure files.
 autoload -Uz compinit && compinit -i
+
+# Docker CLI completion
+# Generate once with:
+#   mkdir -p ~/.docker/completions
+#   docker completion zsh > ~/.docker/completions/_docker
 
 # Azure CLI completion
 if [[ -n "$BREW_PREFIX" ]] && command -v az >/dev/null 2>&1; then

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -71,6 +71,17 @@ The configuration is **fully modular and defensive** - every tool invocation che
 
 All tool-specific features (completions, plugins, integrations) are wrapped in conditional checks, so missing tools never cause errors.
 
+### Docker CLI Completion
+
+If Docker Desktop is installed, generate the zsh completion once and store it in `~/.docker/completions/_docker`:
+
+```bash
+mkdir -p ~/.docker/completions
+docker completion zsh > ~/.docker/completions/_docker
+```
+
+`zsh/.zshrc` adds `~/.docker/completions` to `FPATH` before `compinit`, so new shells will pick it up automatically.
+
 ### Conditional Tool Loading
 
 The configuration dynamically adapts based on which tools are installed:
@@ -79,6 +90,7 @@ The configuration dynamically adapts based on which tools are installed:
 - **FZF** (fuzzy finder) with optimizations if available
 - **Starship** prompt if available
 - **mise** runtime activation if installed
+- **Docker** CLI completion if `~/.docker/completions/_docker` exists
 - **kubectl** completions and aliases if available
 - **direnv** integration if available
 - Plugins like **zsh-autosuggestions** and **zsh-syntax-highlighting** if available via Homebrew


### PR DESCRIPTION
## Summary
- split SSH setup into a base `~/.ssh/config` plus per-profile `config.d` fragments, with new examples and updated setup/docs
- add Azure DevOps SSH alias and Git URL rewrite examples for work profiles
- add Docker zsh completion support and document the one-time completion generation step
- switch OpenTofu installation from `arkade` to Homebrew in the infrastructure profile
- update 1Password and shell tests to cover the new SSH and zsh behavior
- add the `tui-glamorous` skill and its reference material

## Testing
- `bats _test/1password.bats`
- `bats _test/shell-configs.bats`
- `bash -n setup-gitconfig-from-1password.sh`
- `zsh -n zsh/.zshrc`
- `git diff --check`