### PR TITLE
Stabilize update flow and reduce skill duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,15 @@ Thumbs.db
 *.bak
 *.cache
 _audit/
+.generated/update-plans/
 
 # Local reference repos
 _reference/
 
+# JSM-managed skills are installed locally and may include paid content.
+# Already tracked skills remain tracked; new local installs stay out of git.
 skills/.SKILLS_MANAGED_BY_JSM
+skills/*
 
 # Local compiled tools
 bin/browser-tools

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(BLUE)Environment variables:$(NC)"
 	@echo "  VSCODE_CLI                VSCode binary to use (default: code)"
+	@echo "  BREW_REFRESH=true         Refresh Homebrew metadata during config-driven updates"
 	@echo ""
 	@echo "$(BLUE)Profile Examples:$(NC)"
 	@echo "  make install             Safe base install (common profile by default)"
@@ -208,7 +209,7 @@ FOCUS_AREAS = ai app-store cloud container-base containers hardware-home infrast
 # Dynamic pattern rule for focus areas
 .PHONY: $(FOCUS_AREAS)
 $(FOCUS_AREAS):
-	@CONFIG_FILES="focus/$@" ./install.sh $(if $(filter update,$(MAKECMDGOALS)),-u) $(if $(filter stow,$(MAKECMDGOALS)),-s) $(if $(filter install-dry-run,$(MAKECMDGOALS)),-d)
+	@UPDATE_MANIFEST_PATH=".generated/update-plans/focus-$@.tsv" CONFIG_FILES="focus/$@" ./install.sh $(if $(filter update,$(MAKECMDGOALS)),-u) $(if $(filter stow,$(MAKECMDGOALS)),-s) $(if $(filter install-dry-run,$(MAKECMDGOALS)),-d) $(if $(filter true,$(DRY_RUN)),-d)
 
 # Help text for focus areas
 ai: ## AI/ML tools <install|stow|update>
@@ -368,7 +369,7 @@ else ifneq ($(filter mas,$(MAKECMDGOALS)),)
 	fi
 else
 	@echo "$(BLUE)Updating $(SELECTED_PROFILE) profile...$(NC)"
-	@CONFIG_FILES="$(PROFILE_CONFIGS)" ./install.sh -u
+	@CONFIG_FILES="$(PROFILE_CONFIGS)" UPDATE_MANIFEST_PATH=".generated/update-plans/$(SELECTED_PROFILE).tsv" ./install.sh -u $(if $(filter true,$(DRY_RUN)),-d)
 endif
 
 ##@ macOS Configuration

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ make cargo update          # Update Rust toolchain and cargo binaries
 make uv update             # Update uv package manager (use ./install.sh -u for uv tools)
 make mas update            # Update Mac App Store applications
 
+# Config-driven updates (target only tools declared in selected configs)
+make update                # Update personal profile tools; writes .generated/update-plans/personal.tsv
+DRY_RUN=true make update   # Preview the same update path without changing tools
+BREW_REFRESH=true make update # Also run brew update before targeted Homebrew upgrades
+
 > **Note:** Mac App Store installs require you to sign in via the App Store app and click "Get" once per app before `make app-store install` (or any `mas install`) can succeed.
 
 > **Note:** Some tools (`arkade`, `slicer`) install their binaries to `/usr/local/bin` which is
@@ -109,6 +114,7 @@ make mas update            # Update Mac App Store applications
 - Installs only tools that match available package managers
 - Uses GNU Stow for configuration management
 - Force mode (`-f`) to handle existing configurations
+- Update manifests under `.generated/update-plans/` show selected tools, managers, and updatable counts
 
 ## Usage
 

--- a/_test/install.bats
+++ b/_test/install.bats
@@ -152,6 +152,7 @@ EOF
   [[ "$output" == *"--list"* ]]
   [[ "$output" == *"$REPO_ROOT/install.sh --list"* ]]
   [[ "$output" == *"--update            Update tools already installed from selected configs; missing tools are skipped"* ]]
+  [[ "$output" == *"BREW_REFRESH=true"* ]]
 }
 
 @test "install.sh rejects list mode with update" {
@@ -168,6 +169,22 @@ $'kubectl\t--version 1.31.0' \
 '[]'
   create_manifest_generator "$manifest_source"
   RESOLVED_CONFIG_FILES=("dummy.yaml")
+
+  generate_manifests
+  [ -f "$MANIFEST_BREWFILE" ]
+  [ -f "$MANIFEST_ARKADE" ]
+  [ -f "$MANIFEST_METADATA" ]
+}
+
+@test "generate_manifests writes manifests even when install is in dry-run mode" {
+  local manifest_source="$BATS_TEST_TMPDIR/manifests"
+  write_manifest_bundle "$manifest_source" \
+'tap "example/tap"' \
+$'kubectl\t--version 1.31.0' \
+'[]'
+  create_manifest_generator "$manifest_source"
+  RESOLVED_CONFIG_FILES=("dummy.yaml")
+  export DRY_RUN="true"
 
   generate_manifests
   [ -f "$MANIFEST_BREWFILE" ]
@@ -381,10 +398,98 @@ esac
   [ "$status" -eq 0 ]
   [[ "$output" == *"Skip: Homebrew taps are managed repositories (1): felixkratz/formulae"* ]]
   [[ "$output" == *"Skip: Homebrew updates disabled by configuration (1): ghostty (cask)"* ]]
+  [[ "$output" == *"Skip: Homebrew metadata refresh skipped; run 'make brew update' separately or set BREW_REFRESH=true"* ]]
   [[ "$output" == *"Info: Updating 1 Homebrew formula..."* ]]
   [[ "$output" == *"Change: Updated 1 Homebrew formula: jq"* ]]
+  run grep -qx -- "update" "$MOCK_CALLS_DIR/brew.calls"
+  [ "$status" -ne 0 ]
+  assert_mock_called "brew" "upgrade jq"
+}
+
+@test "run_brew_update can refresh Homebrew metadata when requested" {
+  export BREW_REFRESH="true"
+  METADATA_LINES=(
+    "jq"$'\t'"brew"$'\t'"package"$'\t'"jq --version"$'\t'"false"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'""
+  )
+
+  # shellcheck disable=SC2016  # mock script is intentionally single-quoted
+  mock_command_with_script "brew" '
+case "$1 $2" in
+  "list --formula")
+    echo "jq"
+    exit 0
+    ;;
+  "list --cask")
+    exit 0
+    ;;
+esac
+
+case "$1" in
+  outdated)
+    if [[ "$2" == "--formula" ]]; then
+      echo "jq"
+    fi
+    exit 0
+    ;;
+  update)
+    echo "brew update ran"
+    exit 0
+    ;;
+  upgrade)
+    echo "upgraded $2"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+'
+
+  run run_brew_update
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Info: Refreshing Homebrew metadata..."* ]]
   assert_mock_called "brew" "update"
   assert_mock_called "brew" "upgrade jq"
+}
+
+@test "write_update_manifest records selected update tools and manager counts" {
+  export UPDATE="true"
+  export UPDATE_MANIFEST_PATH="$BATS_TEST_TMPDIR/update-plan.tsv"
+  export BREW_REFRESH="false"
+  RESOLVED_CONFIG_FILES=("$BATS_TEST_TMPDIR/_configs/host/common.yaml")
+  # shellcheck disable=SC2034  # consumed by write_update_manifest
+  AVAILABLE_MANAGERS=("brew" "manual")
+  METADATA_LINES=(
+    "jq"$'\t'"brew"$'\t'"package"$'\t'"jq --version"$'\t'"false"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"data"$'\t'""
+    "docker-desktop"$'\t'"manual"$'\t'"check"$'\t'"test -d /Applications/Docker.app"$'\t'"true"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"containers"$'\t'""
+  )
+
+  run write_update_manifest
+  [ "$status" -eq 0 ]
+  [ -f "$UPDATE_MANIFEST_PATH" ]
+  run grep -F $'jq\tbrew\tpackage\tyes\tjq --version' "$UPDATE_MANIFEST_PATH"
+  [ "$status" -eq 0 ]
+  run grep -F $'docker-desktop\tmanual\tcheck\tno\ttest -d /Applications/Docker.app' "$UPDATE_MANIFEST_PATH"
+  [ "$status" -eq 0 ]
+  run grep -F $'brew\tpackage\t1\t1' "$UPDATE_MANIFEST_PATH"
+  [ "$status" -eq 0 ]
+}
+
+@test "run_update_phase reports failed phases without suppressing exit status" {
+  export UPDATE="true"
+  # shellcheck disable=SC2034  # consumed by run_update_phase
+  UPDATE_PHASE_INDEX=0
+  # shellcheck disable=SC2034  # consumed by run_update_phase
+  UPDATE_PHASE_TOTAL=1
+
+  failing_update_step() {
+    return 7
+  }
+
+  run run_update_phase "Failing demo phase" failing_update_step
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"Info: Phase 1/1: Failing demo phase"* ]]
+  [[ "$output" == *"Fail: Phase 1/1 failed after"* ]]
 }
 
 @test "run_arkade_batch builds a single batch command from the TSV manifest" {
@@ -463,6 +568,42 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"Change: Installed 1 VSCode extension(s)"* ]]
   assert_mock_called "code" "--install-extension esbenp.prettier-vscode"
+}
+
+@test "run_code_extensions uses VSCode updater during update mode" {
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export UPDATE="true"
+  mkdir -p "$HOME"
+  METADATA_LINES=(
+    "prettier-vscode"$'\t'"code"$'\t'"extension"$'\t'"code --list-extensions | grep -q esbenp.prettier-vscode"$'\t'"false"$'\t'"null"$'\t'"esbenp.prettier-vscode"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'""
+  )
+  cat > "$MOCK_BIN_DIR/code" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$MOCK_CALLS_DIR/code.calls"
+case "$1" in
+  --list-extensions)
+    echo "esbenp.prettier-vscode"
+    exit 0
+    ;;
+  --update-extensions)
+    echo "updating extensions"
+    exit 0
+    ;;
+  --install-extension)
+    exit 2
+    ;;
+esac
+exit 0
+EOF
+  chmod +x "$MOCK_BIN_DIR/code"
+
+  run run_code_extensions
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Info: Updating VSCode extensions via profile-wide updater for 1 selected installed extension(s)..."* ]]
+  [[ "$output" == *"Info: Updated VSCode extensions"* ]]
+  assert_mock_called "code" "--update-extensions"
+  run grep -q -- "--install-extension" "$MOCK_CALLS_DIR/code.calls"
+  [ "$status" -ne 0 ]
 }
 
 @test "run_brew_fallback_if_needed installs brew packages through apt when Homebrew is unavailable" {

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -173,6 +173,13 @@ teardown() {
   [[ "$output" =~ "-u" ]]
 }
 
+@test "make update passes dry-run flag when requested" {
+  DRY_RUN=true run make update
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "-u" ]]
+  [[ "$output" =~ "-d" ]]
+}
+
 @test "PROFILE environment variable overrides selection" {
   PROFILE=work run make install
   [ "$status" -eq 0 ]

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -49,6 +49,10 @@ paths=(
   "$HOME/.cargo/bin"
   "$HOME/.tfenv/bin"
   "$HOME/.arkade/bin"
+  "$HOME/.lmstudio/bin"
+  "$HOME/.omlx/bin"
+  "$HOME/.ollama/bin"
+  "$HOME/.vmlx/bin"
 )
 
 for path_entry in "${paths[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,10 @@ Options:
   -u, --update            Update tools already installed from selected configs; missing tools are skipped
   -v, --verbose           Show raw package-manager output
 
+Environment:
+  BREW_REFRESH=true       Run brew update before config-driven Homebrew upgrades
+  UPDATE_MANIFEST_PATH    Write an update manifest to this path during --update
+
 Examples:
   $0
   $0 -c focus/vscode

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -29,6 +29,8 @@ FORCE="${FORCE:-false}"
 UPDATE="${UPDATE:-false}"
 LIST_MODE="${LIST_MODE:-false}"
 CONFIG_FILES_SET_VIA_CLI="${CONFIG_FILES_SET_VIA_CLI:-false}"
+BREW_REFRESH="${BREW_REFRESH:-false}"
+UPDATE_MANIFEST_PATH="${UPDATE_MANIFEST_PATH:-}"
 
 INSTALL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_REPO_ROOT="${INSTALL_REPO_ROOT:-$(cd "$INSTALL_LIB_DIR/.." && pwd)}"
@@ -54,6 +56,8 @@ BREW_UPDATE_FORMULAS=()
 BREW_UPDATE_CASKS=()
 MAS_UPDATE_LINES=()
 BREW_BUNDLE_SKIP_ENV=()
+UPDATE_PHASE_INDEX=0
+UPDATE_PHASE_TOTAL=8
 
 command_exists() {
   type "$1" >/dev/null 2>&1
@@ -108,6 +112,38 @@ debug() {
   if is_verbose; then
     emit_log "Info" "$@"
   fi
+}
+
+run_update_phase() {
+  local name=$1
+  shift
+
+  if [[ "$UPDATE" != "true" ]]; then
+    "$@"
+    return $?
+  fi
+
+  local started_at
+  local elapsed
+  local status
+
+  UPDATE_PHASE_INDEX=$((UPDATE_PHASE_INDEX + 1))
+  started_at=$(timestamp_now)
+  info "Phase ${UPDATE_PHASE_INDEX}/${UPDATE_PHASE_TOTAL}: $name"
+  if "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+  elapsed=$(duration_since "$started_at")
+
+  if [[ $status -eq 0 ]]; then
+    info "Phase ${UPDATE_PHASE_INDEX}/${UPDATE_PHASE_TOTAL} completed in $elapsed: $name"
+  else
+    error "Phase ${UPDATE_PHASE_INDEX}/${UPDATE_PHASE_TOTAL} failed after $elapsed: $name"
+  fi
+
+  return "$status"
 }
 
 timestamp_now() {
@@ -545,7 +581,9 @@ print_available_tool_catalog() {
   local auto_install
   local updatable
 
-  mapfile -t catalog_files < <(collect_catalog_config_files)
+  while IFS= read -r config_file; do
+    [[ -n "$config_file" ]] && catalog_files+=("$config_file")
+  done < <(collect_catalog_config_files)
   if [[ ${#catalog_files[@]} -eq 0 ]]; then
     error "No configuration files available to list"
     return 1
@@ -625,7 +663,7 @@ generate_manifests() {
     info "Generating manifests for ${#RESOLVED_CONFIG_FILES[@]} config file(s)..."
   fi
 
-  run_and_capture "$MANIFEST_GENERATOR" "$MANIFEST_DIR" "${RESOLVED_CONFIG_FILES[@]}"
+  run_and_capture env DRY_RUN=false "$MANIFEST_GENERATOR" "$MANIFEST_DIR" "${RESOLVED_CONFIG_FILES[@]}"
   if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
     error "Manifest generation failed"
     return "$CAPTURE_EXIT_CODE"
@@ -1432,18 +1470,22 @@ run_brew_update() {
     return 0
   fi
 
-  info "Refreshing Homebrew metadata..."
-  if is_dry_run; then
-    info "Would execute: brew update"
-  else
-    started_at=$(timestamp_now)
-    run_and_capture brew update
-    if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
-      error "brew update failed"
-      return "$CAPTURE_EXIT_CODE"
+  if [[ "$BREW_REFRESH" == "true" ]]; then
+    info "Refreshing Homebrew metadata..."
+    if is_dry_run; then
+      info "Would execute: brew update"
+    else
+      started_at=$(timestamp_now)
+      run_and_capture brew update
+      if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
+        error "brew update failed"
+        return "$CAPTURE_EXIT_CODE"
+      fi
+      elapsed=$(duration_since "$started_at")
+      info "Refreshed Homebrew metadata in $elapsed"
     fi
-    elapsed=$(duration_since "$started_at")
-    info "Refreshed Homebrew metadata in $elapsed"
+  else
+    skip "Homebrew metadata refresh skipped; run 'make brew update' separately or set BREW_REFRESH=true"
   fi
 
   if [[ ${#BREW_UPDATE_FORMULAS[@]} -gt 0 ]]; then
@@ -1452,7 +1494,7 @@ run_brew_update() {
       info "Would execute: brew upgrade $(join_by_space "${BREW_UPDATE_FORMULAS[@]}")"
     else
       started_at=$(timestamp_now)
-      run_and_capture brew upgrade "${BREW_UPDATE_FORMULAS[@]}"
+      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade "${BREW_UPDATE_FORMULAS[@]}"
       if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
         error "brew formula upgrade failed"
         return "$CAPTURE_EXIT_CODE"
@@ -1468,7 +1510,7 @@ run_brew_update() {
       info "Would execute: brew upgrade --cask $(join_by_space "${BREW_UPDATE_CASKS[@]}")"
     else
       started_at=$(timestamp_now)
-      run_and_capture brew upgrade --cask "${BREW_UPDATE_CASKS[@]}"
+      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade --cask "${BREW_UPDATE_CASKS[@]}"
       if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
         error "brew cask upgrade failed"
         return "$CAPTURE_EXIT_CODE"
@@ -1740,6 +1782,7 @@ run_arkade_batch() {
 run_code_extensions() {
   local vscode_cli
   local -a install_ids=()
+  local -a update_ids=()
   local line
   local tool manager type check_command extension_id install_args
 
@@ -1780,7 +1823,7 @@ run_code_extensions() {
 
     if is_tool_installed_from_fields "$tool" "$manager" "$type" "$check_command" "$extension_id"; then
       if [[ "$UPDATE" == "true" ]]; then
-        install_ids+=("$extension_id"$'\t'"$install_args")
+        update_ids+=("$extension_id")
       else
         skip "$tool (code extension) already installed"
       fi
@@ -1792,6 +1835,27 @@ run_code_extensions() {
       fi
     fi
   done
+
+  if [[ "$UPDATE" == "true" ]]; then
+    if [[ ${#update_ids[@]} -eq 0 ]]; then
+      return 0
+    fi
+
+    info "Updating VSCode extensions via profile-wide updater for ${#update_ids[@]} selected installed extension(s)..."
+    if is_dry_run; then
+      info "Would execute: $vscode_cli --update-extensions"
+      return 0
+    fi
+
+    run_and_capture "$vscode_cli" --update-extensions
+    if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
+      error "VSCode extension update failed"
+      return "$CAPTURE_EXIT_CODE"
+    fi
+
+    info "Updated VSCode extensions"
+    return 0
+  fi
 
   if [[ ${#install_ids[@]} -eq 0 ]]; then
     return 0
@@ -1818,11 +1882,7 @@ run_code_extensions() {
     return "$CAPTURE_EXIT_CODE"
   fi
 
-  if [[ "$UPDATE" == "true" ]]; then
-    change "Refreshed ${#install_ids[@]} VSCode extension(s)"
-  else
-    change "Installed ${#install_ids[@]} VSCode extension(s)"
-  fi
+  change "Installed ${#install_ids[@]} VSCode extension(s)"
 }
 
 run_manual_messages() {
@@ -2216,6 +2276,66 @@ refresh_available_managers() {
   fi
 }
 
+write_update_manifest() {
+  if [[ "$UPDATE" != "true" || -z "$UPDATE_MANIFEST_PATH" ]]; then
+    return 0
+  fi
+
+  local manifest_dir
+  manifest_dir=$(dirname "$UPDATE_MANIFEST_PATH")
+  mkdir -p "$manifest_dir"
+
+  {
+    printf '# n-dotfiles update manifest\n'
+    printf '# generated_at\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '# brew_refresh\t%s\n' "$BREW_REFRESH"
+    printf '# configs'
+    local config_file
+    for config_file in "${RESOLVED_CONFIG_FILES[@]}"; do
+      printf '\t%s' "$config_file"
+    done
+    printf '\n'
+    printf '# available_managers'
+    local manager
+    for manager in "${AVAILABLE_MANAGERS[@]}"; do
+      printf '\t%s' "$manager"
+    done
+    printf '\n'
+    printf '\n'
+    printf 'tool\tmanager\ttype\tupdatable\tcheck_command\n'
+    local line
+    local tool type check_command skip_update
+    for line in "${METADATA_LINES[@]:-}"; do
+      IFS=$'\t' read -r tool manager type check_command skip_update _ _ _ _ _ _ _ <<<"$line"
+      if [[ -z "$tool" || -z "$manager" ]]; then
+        continue
+      fi
+      if [[ "$skip_update" == "true" || "$manager" == "manual" ]]; then
+        printf '%s\t%s\t%s\tno\t%s\n' "$tool" "$manager" "$type" "$check_command"
+      else
+        printf '%s\t%s\t%s\tyes\t%s\n' "$tool" "$manager" "$type" "$check_command"
+      fi
+    done
+    printf '\n'
+    printf 'manager\ttype\ttotal\tupdatable\n'
+    printf '%s\n' "${METADATA_LINES[@]:-}" | awk -F '\t' '
+      NF >= 5 && $1 != "" && $2 != "" {
+        total[$2 "\t" $3]++
+        if ($5 != "true" && $2 != "manual") {
+          updatable[$2 "\t" $3]++
+        }
+      }
+      END {
+        for (key in total) {
+          print key "\t" total[key] "\t" (key in updatable ? updatable[key] : 0)
+        }
+      }
+    ' | sort
+  } >"$UPDATE_MANIFEST_PATH"
+
+  info "Wrote update manifest: $UPDATE_MANIFEST_PATH"
+}
+
 clear_zsh_cache_if_needed() {
   if [[ "$UPDATE" != "true" || "$DRY_RUN" == "true" ]]; then
     return 0
@@ -2280,14 +2400,15 @@ main() {
     fi
 
     if [[ "$UPDATE" == "true" ]]; then
-      run_brew_update || return 1
-      run_mas_update || return 1
-      run_brew_fallback_if_needed || return 1
-      run_direct_metadata_tools || return 1
-      run_arkade_batch || return 1
-      run_code_extensions || return 1
-      run_manual_messages || return 1
-      run_mise_update || return 1
+      write_update_manifest || return 1
+      run_update_phase "Homebrew formulae and casks" run_brew_update || return 1
+      run_update_phase "Mac App Store apps" run_mas_update || return 1
+      run_update_phase "APT fallback packages" run_brew_fallback_if_needed || return 1
+      run_update_phase "Direct package managers" run_direct_metadata_tools || return 1
+      run_update_phase "Arkade tools" run_arkade_batch || return 1
+      run_update_phase "VSCode extensions" run_code_extensions || return 1
+      run_update_phase "Manual tool reminders" run_manual_messages || return 1
+      run_update_phase "mise runtimes" run_mise_update || return 1
       clear_zsh_cache_if_needed
     else
       run_brew_install || return 1

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "skills": {
+    "caveman": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/caveman/SKILL.md",
+      "computedHash": "934433479903febc585bf6deb5f0cebc63137e3f86b7babe0aab1ecb94d6d7a4"
+    },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "31a5b1ae116558bf7d3f633f442835f54bd7645923d4f45c7823e52a97317666"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+    },
+    "tdd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/tdd/SKILL.md",
+      "computedHash": "15a7b5e36383ebadb2dec5e586679e55e9663d292da418926b8da6fc0ef27d84"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-issues/SKILL.md",
+      "computedHash": "47f648f3414848ccfc62cb41d2828b7e575fb5e7cbd6c4bdf630c063b5dc5e82"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-prd/SKILL.md",
+      "computedHash": "6d741474efd4bc3db55fabc2722ed78ca9c374cabcb6212936d79d4fd4a30fcb"
+    },
+    "triage": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/triage/SKILL.md",
+      "computedHash": "2b6efb6da12d92551772fcc04acf331f4e0e6f7bd9d4cb23ce0b301e0b128feb"
+    },
+    "write-a-skill": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/write-a-skill/SKILL.md",
+      "computedHash": "b44d8aab2ead83c716e01af4c9a24ccc4575ce70ad58ec4f1749fb88c9cc82ba"
+    },
+    "zoom-out": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/zoom-out/SKILL.md",
+      "computedHash": "8357aeaece3b709c442eab67e64b86844e05e2f1ea95b109565eba50b6def36e"
+    }
+  }
+}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -185,6 +185,10 @@ declare -a early_paths=(
   "$HOME/.tfenv/bin"
   "$HOME/slicer-mac"
   "$HOME/.arkade/bin"
+  "$HOME/.lmstudio/bin"
+  "$HOME/.omlx/bin"
+  "$HOME/.ollama/bin"
+  "$HOME/.vmlx/bin"
 )
 
 for path_entry in "${early_paths[@]}"; do
@@ -311,6 +315,10 @@ declare -a paths=(
   "$HOME/.tfenv/bin"
   "$HOME/slicer-mac"
   "$HOME/.arkade/bin"
+  "$HOME/.lmstudio/bin"
+  "$HOME/.omlx/bin"
+  "$HOME/.ollama/bin"
+  "$HOME/.vmlx/bin"
 )
 
 for path_entry in "${paths[@]}"; do

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -491,7 +491,7 @@ fi
 # 17. mise (polyglot runtime manager)
 #
 if command -v mise >/dev/null 2>&1; then
-  _cache_init mise "mise activate zsh"
+  eval "$(/opt/homebrew/bin/mise activate zsh)"
 fi
 
 #


### PR DESCRIPTION
## Summary
- Ignore local JSM-managed skill installs and generated update manifests in git.
- Make `make update` progress visible with per-phase output and an optional manifest.
- Decouple Homebrew metadata refresh from config-driven updates unless `BREW_REFRESH=true` is set.
- Fix VSCode extension updates so update mode uses `code --update-extensions` instead of replaying install commands.
- Restore LM Studio, Ollama, OMLX, and VMLX PATH handling in shell startup.
- Remove Conda shell init and document uninstall steps.

## Testing
- `bats install.bats`
- `bats makefile.bats`
- `./_test/run_tests.sh`
- `./_test/shellcheck.sh`
- `./skills/shell-cli-contract-audit/scripts/audit-shell-cli-contracts.sh --format tsv .`
- Manual verification of `DRY_RUN=true make update` and `make update`