### PR TITLE
Add harness guide audit and shared harness glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,173 @@
+# n-dotfiles
+
+This context names the concepts used to manage public, private, and agent-visible automation assets in this dotfiles repository.
+
+## Language
+
+**Skill Catalog**:
+The curated set of skills that should be available for agent use on this machine.
+_Avoid_: skill pile, installed skills
+
+**Agent Harness**:
+An LLM coding environment such as Claude Code, Codex, OpenCode, or a related desktop wrapper.
+_Avoid_: coding agent, tool, client
+
+**Harness Asset**:
+A durable configuration artifact used by an **Agent Harness**, such as a skill, agent, MCP server declaration, plugin, hook, rule, or setting.
+_Avoid_: skill, agent stuff, config file
+
+**Asset Catalog**:
+The curated set of **Harness Assets** that should be available on this machine.
+_Avoid_: skill catalog, Chops library
+
+**Harness Repository**:
+A repository that stores portable **Harness Assets** and the rules for exposing them to **Agent Harnesses**.
+_Avoid_: agents repo, skills repo
+
+**Private Harness Repository**:
+A separate non-public **Harness Repository** for paid, private, or personal-only **Harness Assets**.
+_Avoid_: private skills folder, secret dotfiles
+
+**Optional Private Source**:
+A **Private Harness Repository** that is used only when present and skipped without error when absent.
+_Avoid_: required private checkout, missing dependency
+
+**Shared Asset Source**:
+A top-level area in a **Harness Repository** for **Harness Assets** that are intended to be reused across harnesses.
+_Avoid_: shared folder, global copy
+
+**Harness View**:
+The harness-specific layout that an **Agent Harness** or Chops scans.
+_Avoid_: generated copy, installed folder
+
+**Chops View**:
+The catalog Chops displays by reading assets exposed through **Harness Views**.
+_Avoid_: Chops source, Chops database
+
+**Runtime State**:
+Ephemeral or machine-local data created while an **Agent Harness** runs.
+_Avoid_: config, setup
+
+**Visible Skill Root**:
+A directory scanned by an app or agent to discover available skills.
+_Avoid_: skills folder, install location
+
+**Global Skill Root**:
+The Chops-visible skill root currently represented by `~/.agents/skills`.
+_Avoid_: global skills, dot agents
+
+**Shared Skill Root**:
+The single **Visible Skill Root** used for skills that should be available across agents.
+_Avoid_: common skills folder, global skills folder
+
+**Agent-Specific Skill Root**:
+A **Visible Skill Root** reserved for skills that genuinely need to differ for a specific agent.
+_Avoid_: duplicate agent folder, per-tool copy
+
+**Duplicate Skill**:
+The same skill content exposed from more than one **Visible Skill Root**.
+_Avoid_: duplicate directory, duplicate version
+
+**Skill Drift**:
+The same skill name resolving to different content in different **Visible Skill Roots**.
+_Avoid_: duplicate, fork
+
+**Skill Reset**:
+A deliberate one-time replacement of existing installed skills with a smaller curated set from known sources.
+_Avoid_: dedupe, cleanup
+
+**Symlink Route**:
+The path by which a **Harness View** exposes a source **Harness Asset** to an **Agent Harness**.
+_Avoid_: copy, install path
+
+**Discovery Route**:
+The path or configured location an **Agent Harness** or Chops scans to find **Harness Assets**.
+_Avoid_: symlink route, folder layout
+
+**Placeholder Asset**:
+An empty or inert file at a known harness path that should not be treated as meaningful configuration.
+_Avoid_: config, rule, instruction
+
+**Project Harness Guide**:
+A repository-local instruction file such as `AGENTS.md` or `CLAUDE.md` that tells harnesses how to work in that project.
+_Avoid_: global instruction, harness asset
+
+**Workspace Harness Audit**:
+A read-only scan across local repositories that reports **Project Harness Guides** and their references to repo-local skills.
+_Avoid_: installer, migration, reset
+
+**Bloated Harness Guide**:
+A long `AGENTS.md`, `CLAUDE.md`, or equivalent **Project Harness Guide** that may contain copied guidance better kept in repo-local skills or docs.
+_Avoid_: legacy Claude guide, canonical guide
+
+## Relationships
+
+- A **Skill Catalog** is exposed through one or more **Visible Skill Roots**.
+- An **Asset Catalog** contains one or more kinds of **Harness Assets**.
+- A **Harness Repository** contains a **Shared Asset Source** and zero or more **Harness Views**.
+- An **Optional Private Source** contributes private **Harness Assets** without being required for public setup.
+- An **Agent Harness** uses **Harness Assets** and produces **Runtime State**.
+- A **Chops View** reflects **Harness Views** and should not introduce its own source layout.
+- A **Shared Skill Root** is the default home for cross-agent skills.
+- The **Global Skill Root** is a candidate implementation of the **Shared Skill Root**.
+- An **Agent-Specific Skill Root** is an exception for skills that differ by agent.
+- A **Duplicate Skill** can exist even when copied files are byte-for-byte identical.
+- **Skill Drift** is distinct from a **Duplicate Skill** and must be resolved deliberately.
+- A **Skill Reset** avoids preserving accidental historical installs as part of the new catalog.
+- A **Symlink Route** should make the source of each exposed asset clear without copying private content.
+- A **Discovery Route** is a harness behavior and should be understood before choosing a **Symlink Route**.
+- A **Placeholder Asset** may indicate a possible **Discovery Route** but is not part of the curated catalog until it has content.
+- A **Project Harness Guide** can reference repo-local skills without making those skills part of the global **Asset Catalog**.
+- A **Workspace Harness Audit** belongs with other local repo audits and should not mutate harness configuration.
+- A **Bloated Harness Guide** is a review signal because it may duplicate guidance that belongs in repo-local skills or docs.
+
+## Example dialogue
+
+> **Dev:** "Chops shows `changelog-md-workmanship` under both Claude and Codex. Is that two versions?"
+> **Domain expert:** "No, that is a **Duplicate Skill** because the same skill is visible from two **Visible Skill Roots**."
+
+> **Dev:** "Where should `changelog-md-workmanship` live if both Claude and Codex can use it?"
+> **Domain expert:** "In the **Shared Skill Root**, unless one agent needs a materially different version."
+
+> **Dev:** "What if `grill-with-docs` has different content under Global and Codex?"
+> **Domain expert:** "That is **Skill Drift**, not a harmless **Duplicate Skill**."
+
+> **Dev:** "Should setup infer the correct catalog by deduplicating every old skill?"
+> **Domain expert:** "No. A **Skill Reset** starts from known sources and only re-adds selected skills."
+
+> **Dev:** "Do we need backups before rebuilding installed skill roots?"
+> **Domain expert:** "No. The sources are version controlled; the important part is clear **Symlink Routes**."
+
+> **Dev:** "Should we decide whole-directory symlinks before checking harness settings?"
+> **Domain expert:** "No. First identify the **Discovery Routes**; then choose the simplest **Symlink Routes** that do not duplicate them."
+
+> **Dev:** "`~/.codex/AGENTS.md` exists but is empty. Is that a managed rule?"
+> **Domain expert:** "No. It is a **Placeholder Asset** unless we intentionally put global Codex instructions there."
+
+> **Dev:** "A repo has `AGENTS.md` pointing at `skills/use-platform/SKILL.md`. Is that a global skill?"
+> **Domain expert:** "No. That is a **Project Harness Guide** referencing a repo-local skill."
+
+> **Dev:** "Should we audit all personal repos for `CLAUDE.md`, `AGENTS.md`, and skill references?"
+> **Domain expert:** "Yes. That is a **Workspace Harness Audit**, not an install or reset step."
+
+> **Dev:** "Is a `CLAUDE.md` or `AGENTS.md` file automatically healthy project guidance?"
+> **Domain expert:** "No. Treat long guide files as possible **Bloated Harness Guides** until they are shown to delegate cleanly."
+
+> **Dev:** "Should logs and session databases go in dotfiles with MCP settings?"
+> **Domain expert:** "No. MCP settings are **Harness Assets**; logs and sessions are **Runtime State**."
+
+> **Dev:** "Chops shows Skills, Agents, and Rules. Are we only managing skills?"
+> **Domain expert:** "No. Skills are one kind of **Harness Asset** in the broader **Asset Catalog**."
+
+> **Dev:** "Should `shared/` be scanned directly by agents?"
+> **Domain expert:** "No. `shared/` is the **Shared Asset Source**; agents and Chops should scan **Harness Views**."
+
+> **Dev:** "What if private paid skills are not cloned on a new machine?"
+> **Domain expert:** "The **Optional Private Source** is skipped without error, so those skills are simply unavailable."
+
+> **Dev:** "Should Chops scan source folders like `shared/`?"
+> **Domain expert:** "No. The **Chops View** should reflect the same **Harness Views** exposed to Claude, Codex, and other harnesses."
+
+## Flagged ambiguities
+
+- "No duplication" means eliminating duplicate visible skills, not only deleting duplicate tracked files from the repository.

--- a/_test/cli-contracts.bats
+++ b/_test/cli-contracts.bats
@@ -33,6 +33,7 @@ assert_help_contract() {
     "scripts/generate-brewfile.sh"
     "scripts/generate-install-manifests.sh"
     "scripts/audit.sh"
+    "scripts/audit-harness-guides.sh"
     "scripts/audit-installed.sh"
     "scripts/build-browser-tools.sh"
     "slicer-mac/check-slicer-version.sh"

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -105,3 +105,7 @@ if [ -f "$HOME/.bashrc.local" ]; then
   # shellcheck disable=SC1091
   source "$HOME/.bashrc.local"
 fi
+
+# BEGIN superterm
+eval "$(superterm shell-init bash)"
+# END superterm

--- a/harnesses/README.md
+++ b/harnesses/README.md
@@ -1,0 +1,65 @@
+# Harnesses
+
+This directory records the intended source layout for portable agent harness
+configuration. It does not currently install or reset live harness state.
+
+## Model
+
+- `shared/` is the public source for harness assets that can be reused across
+  Claude Code, Codex, Gemini, OpenCode, and similar tools.
+- Harness-specific directories are only for assets that need a different format
+  or behavior for one harness.
+- Private or paid assets live outside this public repo, by default in a sibling
+  `../harnesses-private` repository.
+- Setup must tolerate `../harnesses-private` being absent.
+- Chops is a viewer of installed harness paths, not a source of truth.
+
+## Proposed Layout
+
+```text
+harnesses/
+  shared/
+    skills/
+    agents/
+    rules/
+    mcps/
+  claude/
+    skills/
+    agents/
+    rules/
+    settings/
+  codex/
+    skills/
+    agents/
+    rules/
+    settings/
+  gemini/
+  opencode/
+```
+
+## Discovery Before Symlinks
+
+Before changing live paths, document where each harness actually discovers
+assets:
+
+- Global / Chops: `~/.agents/skills`
+- Claude Code: `~/.claude/skills` and any global roots it also reads
+- Codex: `~/.codex/skills`, built-in skills, and plugin-provided skills
+
+Choose symlink routes only after discovery routes are clear. The goal is one
+visible route for each shared asset, with harness-specific routes only for real
+exceptions.
+
+## Workspace Audits
+
+Use the read-only harness guide audit to find repo-local instruction files that
+may need cleanup:
+
+```bash
+scripts/audit-harness-guides.sh --dry-run
+scripts/audit-harness-guides.sh --execute
+scripts/audit-harness-guides.sh --execute --all --format tsv
+```
+
+The audit reports `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` size metrics plus
+repo-local skill references. Large guide files are review signals, not failures.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,20 @@ each repo's current branch with `origin/main` without network access by default.
 ./scripts/audit-local-git-repos.sh --execute --root ~/Developer/work --format tsv
 ```
 
+## audit-harness-guides
+
+Read-only audit for repo-local harness guide files such as `AGENTS.md`,
+`CLAUDE.md`, and `GEMINI.md`. It scans one level under the target root and
+reports guide size metrics, repo-local skill references, and likely review
+states.
+
+```bash
+./scripts/audit-harness-guides.sh --dry-run
+./scripts/audit-harness-guides.sh --execute
+./scripts/audit-harness-guides.sh --execute --all
+./scripts/audit-harness-guides.sh --execute --root ~/Developer/work --format tsv
+```
+
 ## list-non-owner-repos
 
 Review local repos whose `origin` remote is not owned by an expected GitHub

--- a/scripts/audit-harness-guides.sh
+++ b/scripts/audit-harness-guides.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$HOME/Developer/personal}"
+FORMAT="${FORMAT:-table}"
+SHOW_ALL=false
+DRY_RUN=false
+EXECUTE=false
+LINE_REVIEW_THRESHOLD="${LINE_REVIEW_THRESHOLD:-60}"
+LINE_BLOATED_THRESHOLD="${LINE_BLOATED_THRESHOLD:-150}"
+WORD_REVIEW_THRESHOLD="${WORD_REVIEW_THRESHOLD:-1000}"
+WORD_BLOATED_THRESHOLD="${WORD_BLOATED_THRESHOLD:-2500}"
+GUIDE_NAMES=("AGENTS.md" "CLAUDE.md" "GEMINI.md")
+TMP_DIR=""
+
+usage() {
+  local exit_code=${1:-0}
+
+  cat <<'EOF'
+Usage: scripts/audit-harness-guides.sh [options] [--dry-run|--execute]
+
+Read-only audit for repo-local harness guide files such as AGENTS.md,
+CLAUDE.md, and GEMINI.md. The default scans one directory level under
+~/Developer/personal and reports guide size, repo-local skill references,
+and likely review states.
+
+Options:
+      --all                       Show ok rows too
+      --dry-run                   Show what would be audited without running it
+      --execute                   Run the audit
+  -f, --format <format>           Output format: table or tsv (default: table)
+  -h, --help                      Show this help message
+      --line-review-threshold <n> Review guide files above this line count
+      --line-bloated-threshold <n>
+                                   Mark guide files above this line count bloated
+      --word-review-threshold <n> Review guide files above this word count
+      --word-bloated-threshold <n>
+                                   Mark guide files above this word count bloated
+  -r, --root <path>               Directory containing local repo directories
+      --shell-entrypoint-descriptor
+                                   Print machine-readable entrypoint metadata
+
+Examples:
+  scripts/audit-harness-guides.sh --dry-run
+  scripts/audit-harness-guides.sh --execute
+  scripts/audit-harness-guides.sh --execute --root ~/Developer/work
+  scripts/audit-harness-guides.sh --execute --all --format tsv
+  scripts/audit-harness-guides.sh --execute --line-review-threshold 40
+EOF
+
+  exit "$exit_code"
+}
+
+error() {
+  echo "Error: $*" >&2
+}
+
+print_entrypoint_descriptor() {
+  printf '{"schema_version":"shell-entrypoint/v1","name":"audit-harness-guides.sh","path":"%s","supports":["--help","--dry-run","--execute"],"default_mode":"dry-run"}\n' "$0"
+}
+
+print_preview() {
+  printf 'INFO dry-run: would scan one directory level under %s\n' "$ROOT_DIR"
+  printf 'INFO dry-run: would inspect guide files: %s\n' "${GUIDE_NAMES[*]}"
+  printf 'INFO dry-run: would count lines, words, and bytes for each guide\n'
+  printf 'INFO dry-run: would report repo-local skill references in guide files\n'
+  printf 'INFO dry-run: output format: %s\n' "$FORMAT"
+  printf 'INFO dry-run: include ok rows: %s\n' "$SHOW_ALL"
+}
+
+parse_positive_int() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || [[ "$value" -eq 0 ]]; then
+    error "$name requires a positive integer"
+    usage 1
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --all)
+        SHOW_ALL=true
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --execute)
+        EXECUTE=true
+        shift
+        ;;
+      -f|--format)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          FORMAT="$2"
+          shift 2
+        else
+          error "--format requires a value"
+          usage 1
+        fi
+        ;;
+      --format=*)
+        FORMAT="${1#*=}"
+        shift
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      --line-review-threshold)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          LINE_REVIEW_THRESHOLD="$2"
+          shift 2
+        else
+          error "--line-review-threshold requires a value"
+          usage 1
+        fi
+        ;;
+      --line-review-threshold=*)
+        LINE_REVIEW_THRESHOLD="${1#*=}"
+        shift
+        ;;
+      --line-bloated-threshold)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          LINE_BLOATED_THRESHOLD="$2"
+          shift 2
+        else
+          error "--line-bloated-threshold requires a value"
+          usage 1
+        fi
+        ;;
+      --line-bloated-threshold=*)
+        LINE_BLOATED_THRESHOLD="${1#*=}"
+        shift
+        ;;
+      --word-review-threshold)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          WORD_REVIEW_THRESHOLD="$2"
+          shift 2
+        else
+          error "--word-review-threshold requires a value"
+          usage 1
+        fi
+        ;;
+      --word-review-threshold=*)
+        WORD_REVIEW_THRESHOLD="${1#*=}"
+        shift
+        ;;
+      --word-bloated-threshold)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          WORD_BLOATED_THRESHOLD="$2"
+          shift 2
+        else
+          error "--word-bloated-threshold requires a value"
+          usage 1
+        fi
+        ;;
+      --word-bloated-threshold=*)
+        WORD_BLOATED_THRESHOLD="${1#*=}"
+        shift
+        ;;
+      -r|--root)
+        if [[ -n "${2:-}" && "$2" != -* ]]; then
+          ROOT_DIR="$2"
+          shift 2
+        else
+          error "--root requires a directory path"
+          usage 1
+        fi
+        ;;
+      --root=*)
+        ROOT_DIR="${1#*=}"
+        shift
+        ;;
+      --shell-entrypoint-descriptor)
+        print_entrypoint_descriptor
+        exit 0
+        ;;
+      *)
+        error "Unknown option: $1"
+        usage 1
+        ;;
+    esac
+  done
+
+  case "$FORMAT" in
+    table|tsv) ;;
+    *)
+      error "Unsupported format: $FORMAT"
+      usage 1
+      ;;
+  esac
+
+  parse_positive_int "--line-review-threshold" "$LINE_REVIEW_THRESHOLD"
+  parse_positive_int "--line-bloated-threshold" "$LINE_BLOATED_THRESHOLD"
+  parse_positive_int "--word-review-threshold" "$WORD_REVIEW_THRESHOLD"
+  parse_positive_int "--word-bloated-threshold" "$WORD_BLOATED_THRESHOLD"
+}
+
+count_lines() {
+  local file="$1"
+
+  wc -l <"$file" | tr -d ' '
+}
+
+count_words() {
+  local file="$1"
+
+  wc -w <"$file" | tr -d ' '
+}
+
+count_bytes() {
+  local file="$1"
+
+  wc -c <"$file" | tr -d ' '
+}
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+
+join_by_comma() {
+  local first=true
+  local item
+
+  for item in "$@"; do
+    if [[ "$first" == "true" ]]; then
+      printf '%s' "$item"
+      first=false
+    else
+      printf ',%s' "$item"
+    fi
+  done
+}
+
+guide_files_for_repo() {
+  local dir="$1"
+  local name
+
+  for name in "${GUIDE_NAMES[@]}"; do
+    if [[ -f "$dir/$name" ]]; then
+      printf '%s\n' "$name"
+    fi
+  done
+}
+
+repo_skill_count() {
+  local dir="$1"
+
+  if [[ ! -d "$dir/skills" ]]; then
+    printf '0\n'
+    return 0
+  fi
+
+  find "$dir/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -type f 2>/dev/null | wc -l | tr -d ' '
+}
+
+skill_refs_for_guides() {
+  local dir="$1"
+  shift
+
+  if [[ "$#" -eq 0 ]]; then
+    return 0
+  fi
+
+  grep -Eho 'skills/[A-Za-z0-9._/-]+' "$@" 2>/dev/null \
+    | sed 's#[).,;:]*$##' \
+    | sort -u \
+    | while IFS= read -r ref; do
+        if [[ -n "$ref" ]]; then
+          printf '%s\n' "$ref"
+        fi
+      done || true
+}
+
+missing_skill_ref_count() {
+  local dir="$1"
+  local refs_file="$2"
+  local count=0
+  local ref
+
+  while IFS= read -r ref; do
+    if [[ -z "$ref" ]]; then
+      continue
+    fi
+
+    if [[ ! -e "$dir/$ref" ]]; then
+      count=$((count + 1))
+    fi
+  done <"$refs_file"
+
+  printf '%s\n' "$count"
+}
+
+scan_repo() {
+  local dir="$1"
+  local rows_file="$2"
+  local name guides guide_paths refs_file guide_count largest_guide largest_lines largest_words largest_bytes
+  local total_words total_lines guide skill_ref_count missing_ref_count skills_count state notes
+
+  name="$(basename "$dir")"
+  mapfile -t guides < <(guide_files_for_repo "$dir")
+  guide_count="${#guides[@]}"
+  skills_count="$(repo_skill_count "$dir")"
+  largest_guide="-"
+  largest_lines=0
+  largest_words=0
+  largest_bytes=0
+  total_words=0
+  total_lines=0
+
+  guide_paths=()
+  for guide in "${guides[@]}"; do
+    local path lines words bytes
+    path="$dir/$guide"
+    lines="$(count_lines "$path")"
+    words="$(count_words "$path")"
+    bytes="$(count_bytes "$path")"
+    total_lines=$((total_lines + lines))
+    total_words=$((total_words + words))
+    guide_paths+=("$path")
+
+    if [[ "$lines" -gt "$largest_lines" || "$words" -gt "$largest_words" ]]; then
+      largest_guide="$guide"
+      largest_lines="$lines"
+      largest_words="$words"
+      largest_bytes="$bytes"
+    fi
+  done
+
+  refs_file="$TMP_DIR/$name.refs"
+  : >"$refs_file"
+  if [[ "${#guide_paths[@]}" -gt 0 ]]; then
+    skill_refs_for_guides "$dir" "${guide_paths[@]}" >"$refs_file"
+  fi
+
+  skill_ref_count="$(count_lines "$refs_file")"
+  missing_ref_count="$(missing_skill_ref_count "$dir" "$refs_file")"
+  state="ok"
+  notes="-"
+
+  if [[ "$missing_ref_count" -gt 0 ]]; then
+    state="missing-skill-ref"
+  elif [[ "$largest_lines" -gt "$LINE_BLOATED_THRESHOLD" || "$largest_words" -gt "$WORD_BLOATED_THRESHOLD" ]]; then
+    state="bloated-guide"
+  elif [[ "$largest_lines" -gt "$LINE_REVIEW_THRESHOLD" || "$largest_words" -gt "$WORD_REVIEW_THRESHOLD" ]]; then
+    state="review-guide"
+  elif [[ "$skills_count" -gt 0 && "$skill_ref_count" -eq 0 ]]; then
+    state="repo-skills-unreferenced"
+  elif [[ "$guide_count" -eq 0 ]]; then
+    state="no-guide"
+  fi
+
+  if [[ "$guide_count" -gt 0 ]]; then
+    notes="$(join_by_comma "${guides[@]}")"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$name" "$guide_count" "$largest_guide" "$largest_lines" "$largest_words" "$largest_bytes" \
+    "$skills_count" "$skill_ref_count" "$missing_ref_count" "$state" "$notes" "$dir" >>"$rows_file"
+}
+
+scan_root() {
+  local rows_file="$1"
+  local dir
+
+  : >"$rows_file"
+
+  while IFS= read -r -d '' dir; do
+    scan_repo "$dir" "$rows_file"
+  done < <(find "$ROOT_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+}
+
+emit_table() {
+  local rows_file="$1"
+  local attention_file="$2"
+  local total_count guide_count no_guide_count review_count bloated_count missing_count unreferenced_count
+
+  total_count="$(count_lines "$rows_file")"
+  guide_count="$(awk -F $'\t' '$2 > 0 {c++} END {print c+0}' "$rows_file")"
+  no_guide_count="$(awk -F $'\t' '$10 == "no-guide" {c++} END {print c+0}' "$rows_file")"
+  review_count="$(awk -F $'\t' '$10 == "review-guide" {c++} END {print c+0}' "$rows_file")"
+  bloated_count="$(awk -F $'\t' '$10 == "bloated-guide" {c++} END {print c+0}' "$rows_file")"
+  missing_count="$(awk -F $'\t' '$10 == "missing-skill-ref" {c++} END {print c+0}' "$rows_file")"
+  unreferenced_count="$(awk -F $'\t' '$10 == "repo-skills-unreferenced" {c++} END {print c+0}' "$rows_file")"
+
+  printf 'Local root:       %s\n' "$ROOT_DIR"
+  printf 'Guide files:      %s\n' "${GUIDE_NAMES[*]}"
+  printf 'Review threshold: %s lines or %s words\n' "$LINE_REVIEW_THRESHOLD" "$WORD_REVIEW_THRESHOLD"
+  printf 'Bloated threshold:%s lines or %s words\n' "$LINE_BLOATED_THRESHOLD" "$WORD_BLOATED_THRESHOLD"
+  printf '\n'
+  printf '%-26s %s\n' "Directories scanned" "$total_count"
+  printf '%-26s %s\n' "Repos with guides" "$guide_count"
+  printf '%-26s %s\n' "No guide" "$no_guide_count"
+  printf '%-26s %s\n' "Review guide" "$review_count"
+  printf '%-26s %s\n' "Bloated guide" "$bloated_count"
+  printf '%-26s %s\n' "Missing skill refs" "$missing_count"
+  printf '%-26s %s\n' "Unreferenced repo skills" "$unreferenced_count"
+
+  if [[ "$SHOW_ALL" == "true" ]]; then
+    sort -t $'\t' -k1,1 "$rows_file" >"$attention_file"
+  else
+    awk -F $'\t' '$10 != "ok" && $10 != "no-guide"' "$rows_file" | sort -t $'\t' -k1,1 >"$attention_file"
+  fi
+
+  if [[ -s "$attention_file" ]]; then
+    printf '\nHarness guides needing attention\n'
+    awk -F $'\t' '
+      BEGIN {
+        printf "%-34s %6s %-14s %7s %7s %7s %6s %6s %6s %-24s %s\n", "LOCAL", "GUIDES", "LARGEST", "LINES", "WORDS", "BYTES", "SKILLS", "REFS", "MISS", "STATE", "PATH"
+      }
+      {
+        printf "%-34s %6s %-14s %7s %7s %7s %6s %6s %6s %-24s %s\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $12
+      }
+    ' "$attention_file"
+  fi
+}
+
+emit_tsv() {
+  local rows_file="$1"
+
+  printf '# summary\n'
+  printf 'metric\tvalue\n'
+  printf 'local_root\t%s\n' "$ROOT_DIR"
+  printf 'guide_files\t%s\n' "${GUIDE_NAMES[*]}"
+  printf 'line_review_threshold\t%s\n' "$LINE_REVIEW_THRESHOLD"
+  printf 'line_bloated_threshold\t%s\n' "$LINE_BLOATED_THRESHOLD"
+  printf 'word_review_threshold\t%s\n' "$WORD_REVIEW_THRESHOLD"
+  printf 'word_bloated_threshold\t%s\n' "$WORD_BLOATED_THRESHOLD"
+  printf 'directories_scanned\t%s\n' "$(count_lines "$rows_file")"
+  printf 'repos_with_guides\t%s\n' "$(awk -F $'\t' '$2 > 0 {c++} END {print c+0}' "$rows_file")"
+
+  printf '# repos\n'
+  printf 'local\tguide_count\tlargest_guide\tlargest_lines\tlargest_words\tlargest_bytes\trepo_skill_count\tskill_ref_count\tmissing_skill_ref_count\tstate\tguides\tpath\n'
+  sort -t $'\t' -k1,1 "$rows_file"
+}
+
+main() {
+  local rows_file attention_file
+
+  parse_args "$@"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_preview
+    exit 0
+  fi
+
+  if [[ "$EXECUTE" != "true" ]]; then
+    usage 0
+  fi
+
+  if [[ ! -d "$ROOT_DIR" ]]; then
+    error "Root directory not found: $ROOT_DIR"
+    exit 1
+  fi
+
+  TMP_DIR="$(mktemp -d)"
+  trap cleanup EXIT
+  rows_file="$TMP_DIR/harness-guides.tsv"
+  attention_file="$TMP_DIR/attention.tsv"
+
+  scan_root "$rows_file"
+
+  case "$FORMAT" in
+    table)
+      emit_table "$rows_file" "$attention_file"
+      ;;
+    tsv)
+      emit_tsv "$rows_file"
+      ;;
+  esac
+}
+
+main "$@"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -50,3 +50,4 @@ set -g @catppuccin_directory_text "#{pane_current_path}"
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
+set -g history-limit 25000

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -610,3 +610,7 @@ if command -v aerospace >/dev/null 2>&1; then
     aerospace-snap &>/dev/null &!
   fi
 fi
+
+# BEGIN superterm
+eval "$(superterm shell-init zsh)"
+# END superterm


### PR DESCRIPTION
## Summary
- Add a read-only `scripts/audit-harness-guides.sh` audit for `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` files with line/word/byte thresholds and repo-local skill reference detection.
- Document the proposed harness layout in `harnesses/README.md` and add the shared vocabulary in `CONTEXT.md` for skills, harnesses, discovery routes, and guide-file hygiene.
- Wire the new script into the existing script docs and CLI contract checks.

## Testing
- `cd _test && bats cli-contracts.bats`
- `./_test/shellcheck.sh`
- Ran `scripts/audit-harness-guides.sh --dry-run` and `--execute` to verify the audit output and summary modes.