### PR TITLE
Add Yazi config, shell integration, and required helpers

### DIFF
--- a/_configs/shared/file-tools.yaml
+++ b/_configs/shared/file-tools.yaml
@@ -16,6 +16,46 @@ tools:
     documentation_url: "https://github.com/eza-community/eza"
     category: file-tools
 
+  ffmpeg:
+    manager: brew
+    type: package
+    check_command: command -v ffmpeg
+    description: "Audio and video toolkit used by Yazi for video thumbnails"
+    documentation_url: "https://www.ffmpeg.org/"
+    category: file-tools
+
+  sevenzip:
+    manager: brew
+    type: package
+    check_command: command -v 7zz
+    description: "Archive extraction and preview support for Yazi"
+    documentation_url: "https://www.7-zip.org/"
+    category: file-tools
+
+  poppler:
+    manager: brew
+    type: package
+    check_command: command -v pdftoppm
+    description: "PDF preview support for Yazi"
+    documentation_url: "https://poppler.freedesktop.org/"
+    category: file-tools
+
+  resvg:
+    manager: brew
+    type: package
+    check_command: command -v resvg
+    description: "SVG preview support for Yazi"
+    documentation_url: "https://github.com/linebender/resvg"
+    category: file-tools
+
+  imagemagick:
+    manager: brew
+    type: package
+    check_command: command -v magick
+    description: "Image conversion support for Yazi font, HEIC, and JPEG XL previews"
+    documentation_url: "https://imagemagick.org/"
+    category: file-tools
+
   ranger:
     manager: brew
     type: package

--- a/yazi/.config/yazi/flavors/eldritch.yazi/flavor.toml
+++ b/yazi/.config/yazi/flavors/eldritch.yazi/flavor.toml
@@ -1,5 +1,3 @@
-"$schema" = "https://yazi-rs.github.io/schemas/theme.json"
-
 [mgr]
 cwd = { fg = "#04d1f9" }
 find_keyword = { fg = "#f1fc79", bold = true, italic = true, underline = true }

--- a/yazi/.config/yazi/keymap.toml
+++ b/yazi/.config/yazi/keymap.toml
@@ -1,0 +1,20 @@
+[[mgr.prepend_keymap]]
+on = "!"
+for = "unix"
+run = 'shell "$SHELL" --block'
+desc = "Open shell here"
+
+[[mgr.prepend_keymap]]
+on = "<Enter>"
+run = "plugin smart-enter"
+desc = "Enter directory or open file"
+
+[[mgr.prepend_keymap]]
+on = ["g", "r"]
+run = 'shell -- ya emit cd "$(git rev-parse --show-toplevel)"'
+desc = "Go to Git root"
+
+[[input.prepend_keymap]]
+on = "<Esc>"
+run = "close"
+desc = "Cancel input"

--- a/yazi/.config/yazi/plugins/smart-enter.yazi/main.lua
+++ b/yazi/.config/yazi/plugins/smart-enter.yazi/main.lua
@@ -1,0 +1,12 @@
+--- @since 25.5.31
+--- @sync entry
+local function setup(self, opts)
+	self.open_multi = opts.open_multi
+end
+
+local function entry(self)
+	local h = cx.active.current.hovered
+	ya.emit(h and h.cha.is_dir and "enter" or "open", { hovered = not self.open_multi })
+end
+
+return { entry = entry, setup = setup }

--- a/yazi/.config/yazi/yazi.toml
+++ b/yazi/.config/yazi/yazi.toml
@@ -1,241 +1,27 @@
-# A TOML linter such as https://taplo.tamasfe.dev/ can use this schema to validate your config.
-# If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
-"$schema" = "https://yazi-rs.github.io/schemas/yazi.json"
-
 [mgr]
-ratio          = [ 1, 3, 4 ]
-sort_by        = "alphabetical"
+ratio = [1, 3, 4]
+sort_by = "alphabetical"
 sort_sensitive = false
-sort_reverse 	 = false
+sort_reverse = false
 sort_dir_first = true
-sort_translit  = false
-linemode       = "none"
-show_hidden    = true
-show_symlink   = true
-scrolloff      = 5
-mouse_events   = [ "click", "scroll" ]
-title_format   = "Yazi: {cwd}"
+sort_translit = false
+linemode = "none"
+show_hidden = true
+show_symlink = true
+scrolloff = 5
+mouse_events = ["click", "scroll"]
+title_format = "Yazi: {cwd}"
 
 [preview]
-wrap            = "no"
-tab_size        = 2
-max_width       = 600
-max_height      = 900
-cache_dir       = ""
-image_delay     = 30
-image_filter    = "triangle"
-image_quality   = 75
-ueberzug_scale  = 1
-ueberzug_offset = [ 0, 0, 0, 0 ]
-
-[opener]
-edit = [
-	{ run = "${EDITOR:-vi} %s", desc = "$EDITOR",      for = "unix", block = true },
-	{ run = "code %s",          desc = "code",         for = "windows", orphan = true },
-	{ run = "code -w %s",       desc = "code (block)", for = "windows", block = true },
-]
-play = [
-	{ run = "xdg-open %s1",    desc = "Play", for = "linux", orphan = true },
-	{ run = "open %s",         desc = "Play", for = "macos" },
-	{ run = 'start "" %s1',    desc = "Play", for = "windows", orphan = true },
-	{ run = "termux-open %s1", desc = "Play", for = "android" },
-	{ run = "mediainfo %s1; echo 'Press enter to exit'; read _", block = true, desc = "Show media info", for = "unix" },
-	{ run = "mediainfo %s1 & pause", block = true, desc = "Show media info", for = "windows" },
-]
-open = [
-	{ run = "xdg-open %s1",    desc = "Open", for = "linux" },
-	{ run = "open %s",         desc = "Open", for = "macos" },
-	{ run = 'start "" %s1',    desc = "Open", for = "windows", orphan = true },
-	{ run = "termux-open %s1", desc = "Open", for = "android" },
-]
-reveal = [
-	{ run = "xdg-open %d1",         desc = "Reveal", for = "linux" },
-	{ run = "open -R %s1",          desc = "Reveal", for = "macos" },
-	{ run = "explorer /select,%s1", desc = "Reveal", for = "windows", orphan = true },
-	{ run = "termux-open %d1",      desc = "Reveal", for = "android" },
-	{ run = "clear; exiftool %s1; echo 'Press enter to exit'; read _", desc = "Show EXIF", for = "unix", block = true },
-]
-extract = [
-	{ run = "ya pub extract --list %s", desc = "Extract here" },
-]
-download = [
-	{ run = "ya emit download --open %S", desc = "Download and open" },
-	{ run = "ya emit download %S",        desc = "Download" },
-]
-
-[open]
-rules = [
-	# Folder
-	{ url = "*/", use = [ "edit", "open", "reveal" ] },
-	# Text
-	{ mime = "text/*", use = [ "edit", "reveal" ] },
-	# Image
-	{ mime = "image/*", use = [ "open", "reveal" ] },
-	# Media
-	{ mime = "{audio,video}/*", use = [ "play", "reveal" ] },
-	# Archive
-	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", use = [ "extract", "reveal" ] },
-	# JSON
-	{ mime = "application/{json,ndjson}", use = [ "edit", "reveal" ] },
-	{ mime = "*/javascript", use = [ "edit", "reveal" ] },
-	# Empty file
-	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
-	# Virtual file system
-	{ mime = "vfs/{absent,stale}", use = "download" },
-	# Fallback
-	{ url = "*", use = [ "open", "reveal" ] },
-]
-
-[tasks]
-micro_workers    = 10
-macro_workers    = 10
-bizarre_retry    = 3
-image_alloc      = 536870912  # 512MB
-image_bound      = [ 10000, 10000 ]
-suppress_preload = false
-
-[plugin]
-fetchers = [
-	# Mimetype
-	{ id = "mime", url = "*/",         run = "mime.dir", prio = "high" },
-	{ id = "mime", url = "local://*",  run = "mime.local", prio = "high" },
-	{ id = "mime", url = "remote://*", run = "mime.remote", prio = "high" },
-]
-spotters = [
-	{ url = "*/", run = "folder" },
-	# Code
-	{ mime = "text/*", run = "code" },
-	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
-	# Image
-	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
-	{ mime = "image/svg+xml", run = "svg" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# Virtual file system
-	{ mime = "vfs/*", run = "vfs" },
-	# Error
-	{ mime = "null/*", run = "null" },
-	# Fallback
-	{ url = "*", run = "file" },
-]
-preloaders = [
-	# Image
-	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
-	{ mime = "image/svg+xml", run = "svg" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# PDF
-	{ mime = "application/pdf", run = "pdf" },
-	# Font
-	{ mime = "font/*", run = "font" },
-	{ mime = "application/ms-opentype", run = "font" },
-]
-previewers = [
-	{ url = "*/", run = "folder" },
-	# Code
-	{ mime = "text/*", run = "code" },
-	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
-	# JSON
-	{ mime = "application/{json,ndjson}", run = "json" },
-	# Image
-	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
-	{ mime = "image/svg+xml", run = "svg" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# PDF
-	{ mime = "application/pdf", run = "pdf" },
-	# Archive
-	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", run = "archive" },
-	{ mime = "application/{debian*-package,redhat-package-manager,rpm,android.package-archive}", run = "archive" },
-	{ url = "*.{AppImage,appimage}", run = "archive" },
-	# Virtual Disk / Disk Image
-	{ mime = "application/{iso9660-image,qemu-disk,ms-wim,apple-diskimage}", run = "archive" },
-	{ mime = "application/virtualbox-{vhd,vhdx}", run = "archive" },
-	{ url = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
-	# Font
-	{ mime = "font/*", run = "font" },
-	{ mime = "application/ms-opentype", run = "font" },
-	# Empty file
-	{ mime = "inode/empty", run = "empty" },
-	# Virtual file system
-	{ mime = "vfs/*", run = "vfs" },
-	# Error
-	{ mime = "null/*", run = "null" },
-	# Fallback
-	{ url = "*", run = "file" },
-]
+wrap = "no"
+tab_size = 2
+max_width = 600
+max_height = 900
+image_delay = 30
+image_filter = "triangle"
+image_quality = 75
+ueberzug_scale = 1
+ueberzug_offset = [0, 0, 0, 0]
 
 [input]
 cursor_blink = false
-
-# cd
-cd_title  = "Change directory:"
-cd_origin = "top-center"
-cd_offset = [ 0, 2, 50, 3 ]
-
-# create
-create_title  = [ "Create:", "Create (dir):" ]
-create_origin = "top-center"
-create_offset = [ 0, 2, 50, 3 ]
-
-# rename
-rename_title  = "Rename:"
-rename_origin = "hovered"
-rename_offset = [ 0, 1, 50, 3 ]
-
-# filter
-filter_title  = "Filter:"
-filter_origin = "top-center"
-filter_offset = [ 0, 2, 50, 3 ]
-
-# find
-find_title  = [ "Find next:", "Find previous:" ]
-find_origin = "top-center"
-find_offset = [ 0, 2, 50, 3 ]
-
-# search
-search_title  = "Search via {n}:"
-search_origin = "top-center"
-search_offset = [ 0, 2, 50, 3 ]
-
-# shell
-shell_title  = [ "Shell:", "Shell (block):" ]
-shell_origin = "top-center"
-shell_offset = [ 0, 2, 50, 3 ]
-
-[confirm]
-# trash
-trash_title 	= "Trash {n} selected file{s}?"
-trash_origin	= "center"
-trash_offset	= [ 0, 0, 70, 20 ]
-
-# delete
-delete_title 	= "Permanently delete {n} selected file{s}?"
-delete_origin	= "center"
-delete_offset	= [ 0, 0, 70, 20 ]
-
-# overwrite
-overwrite_title  = "Overwrite file?"
-overwrite_body   = "Will overwrite the following file:"
-overwrite_origin = "center"
-overwrite_offset = [ 0, 0, 50, 15 ]
-
-# quit
-quit_title  = "Quit?"
-quit_body   = "There are unfinished tasks, quit anyway?\n(Open task manager with default key 'w')"
-quit_origin = "center"
-quit_offset = [ 0, 0, 50, 15 ]
-
-[pick]
-open_title  = "Open with:"
-open_origin = "hovered"
-open_offset = [ 0, 1, 50, 7 ]
-
-[which]
-sort_by      	 = "none"
-sort_sensitive = false
-sort_reverse 	 = false
-sort_translit  = false

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -367,14 +367,24 @@ function y() {
   tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
   command yazi "$@" --cwd-file="$tmp"
   IFS= read -r -d '' cwd <"$tmp"
-  [ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd" || true
-  rm -f -- "$tmp"
+  [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
+  command rm -f -- "$tmp"
 }
+
+# Keep Yazi's directory in sync when exiting a shell opened from inside Yazi.
+if [[ -n "$YAZI_ID" ]] && command -v ya >/dev/null 2>&1; then
+  autoload -Uz add-zsh-hook
+  _yazi_cd() {
+    ya emit cd "$PWD"
+  }
+  add-zsh-hook zshexit _yazi_cd
+fi
 
 # Git aliases
 if command -v git >/dev/null 2>&1; then
   alias gs='git status'
   alias gc='git commit'
+  alias gmain='git switch main && git pull'
 
   # Only add lazygit alias if it's available
   if command -v lazygit >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fix Yazi startup by removing obsolete schema keys and trimming the config to the overrides we actually need
- Add the `y` shell wrapper plus Yazi drop-to-shell behavior so exiting returns to the updated CWD
- Add the Yazi-specific helper packages for previews and archives in `_configs/shared/file-tools.yaml`
- Add the small keymap needed for smart-enter and input close-on-Esc

## Testing
- `yazi --version` succeeds with the stowed config
- `zsh -n zsh/.zshrc` passes
- `bats _test/configs.bats` passes
- Local validation confirmed the active Yazi config is loaded from `~/.config/yazi`