### PR TITLE
Document architecture maps and update harness terminology

### DIFF
--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -1,0 +1,45 @@
+# Skill Loop Progress
+# Skill: repeatedly-apply-skill -> mattpocock-skills:improve-codebase-architecture, with mattpocock-skills:tdd for fixes
+# Target: /Users/nickromney/Developer/personal/n-dotfiles Homebrew update and tap trust path
+# Total Passes: 5
+# Started: 2026-06-01T06:54:29Z
+
+## Status: COMPLETE - Pass 5 of 5
+
+## Missions
+1. Tap trust locality: Deepen the Homebrew tap trust module so trust policy and warning suppression concentrate behind one interface.
+2. Makefile update depth: Deepen the package-manager update interface so Makefile callers stop carrying duplicated Homebrew command sequences.
+3. Config update semantics: Deepen config-driven update handling so tap entries, skip_update entries, and manager update plans have clearer locality.
+4. CLI contract surface: Deepen user-facing CLI contract tests and help text around tap trust/update behavior without coupling to implementation details.
+5. Convergence and report: Re-run architecture review for remaining shallow modules, generate the HTML report, and stop if the path has converged.
+
+## Completed Passes
+### Pass 1 - Tap trust locality - 2026-06-01T07:03:03Z
+- Files changed: Makefile; scripts/brew-with-policy.sh; scripts/install-lib.sh; _test/install.bats; _test/makefile.bats
+- Changes: Added a Homebrew policy adapter that centralizes tap trust environment handling and routed Makefile/config-driven update paths through it.
+- Commit: 614ccac
+- Verdict: PRODUCTIVE
+
+### Pass 2 - Makefile update depth - 2026-06-01T07:10:37Z
+- Files changed: Makefile; scripts/brew-update.sh; _test/makefile.bats
+- Changes: Added a shared Homebrew update module for Makefile callers, preserving required vs optional contexts while removing duplicated update/upgrade/cleanup implementation from the Makefile.
+- Commit: 28a15c2
+- Verdict: PRODUCTIVE
+
+### Pass 3 - Config update semantics - 2026-06-01T07:18:13Z
+- Files changed: scripts/install-lib.sh; _test/install.bats
+- Changes: Replaced shallow Homebrew update queueing with a deeper update-plan interface that avoids Homebrew probes for config-only tap and skip_update entries, while preserving refresh and upgrade behavior.
+- Commit: 4a4d063
+- Verdict: PRODUCTIVE
+
+### Pass 4 - CLI contract surface - 2026-06-01T07:20:44Z
+- Files changed: scripts/brew-with-policy.sh; _test/cli-contracts.bats
+- Changes: Documented the Homebrew tap trust policy interface in the adapter help and added a public CLI contract test that does not require Homebrew.
+- Commit: ccd2b3b
+- Verdict: PRODUCTIVE
+
+### Pass 5 - Convergence and report - 2026-06-01T07:29:16Z
+- Files changed: Makefile; scripts/install-lib.sh; _test/makefile.bats; _test/install.bats
+- Changes: Closed the remaining mutating Homebrew gap by routing brew bundle installs through the policy adapter and adding behavior tests for Makefile and config-driven bundle paths. Generated the architecture review report at /var/folders/y7/ltslr0t54vv51fv7p_xvjr5c0000gn/T/architecture-review-20260601082607.html.
+- Commit: 526f488
+- Verdict: PRODUCTIVE

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,46 @@ _Avoid_: installer, migration, reset
 A long `AGENTS.md`, `CLAUDE.md`, or equivalent **Project Harness Guide** that may contain copied guidance better kept in repo-local skills or docs.
 _Avoid_: legacy Claude guide, canonical guide
 
+**Configuration Bundle**:
+A YAML file under `_configs/` that declares tools, managers, install checks, dependencies, update behavior, and documentation for one slice of the machine setup.
+_Avoid_: package list, config file
+
+**Profile**:
+A named selection of **Configuration Bundles** for a host shape such as `common`, `personal`, `work`, or `all`.
+_Avoid_: environment, machine type
+
+**Focus Area**:
+A single-purpose **Configuration Bundle** exposed as a Makefile target, such as `vscode`, `kubernetes`, or `typescript`.
+_Avoid_: package group, category target
+
+**Install Manifest**:
+A generated file consumed by the install and update engine, such as `Brewfile`, `arkade.tsv`, or `metadata.json`.
+_Avoid_: generated config, output file
+
+**Update Manifest**:
+A generated TSV record of selected update work, including tools, managers, types, and updatable counts.
+_Avoid_: log, report
+
+**Package Manager Adapter**:
+A module that translates **Install Manifest** rows into manager-specific commands for Homebrew, arkade, apt, cargo, uv, mas, mise, VSCode, or manual reporting.
+_Avoid_: installer, plugin
+
+**Stow Tree**:
+A GNU Stow directory such as `zsh/`, `git/`, or `nvim/` whose contents map into `$HOME`.
+_Avoid_: dotfile folder, package
+
+**macOS Profile**:
+A YAML file under `_macos/` that declares macOS defaults and host UI settings for a **Profile**.
+_Avoid_: defaults file, system settings blob
+
+**Setup Flow**:
+A high-level script that composes bootstrap, package installation, macOS settings, Stow, VSCode, and SSH setup without owning those modules' implementations.
+_Avoid_: mega installer, script pile
+
+**Validation Harness**:
+The Bats, mock-command, shellcheck, and smoke-test modules under `_test/` that verify public command interfaces.
+_Avoid_: tests, CI scripts
+
 ## Relationships
 
 - A **Skill Catalog** is exposed through one or more **Visible Skill Roots**.
@@ -120,53 +160,47 @@ _Avoid_: legacy Claude guide, canonical guide
 - A **Project Harness Guide** can reference repo-local skills without making those skills part of the global **Asset Catalog**.
 - A **Workspace Harness Audit** belongs with other local repo audits and should not mutate harness configuration.
 - A **Bloated Harness Guide** is a review signal because it may duplicate guidance that belongs in repo-local skills or docs.
+- A **Profile** is implemented as an ordered list of **Configuration Bundles**.
+- A **Focus Area** bypasses profile composition and sends one **Configuration Bundle** to the install and update engine.
+- A **Configuration Bundle** becomes one or more **Install Manifests** before package operations run.
+- A **Package Manager Adapter** consumes **Install Manifest** rows and owns manager-specific command details.
+- An **Update Manifest** records the selected update surface and should not be treated as the source catalog.
+- A **Stow Tree** changes dotfile symlinks, while a **macOS Profile** changes host defaults.
+- A **Setup Flow** composes modules; it should not duplicate their implementation.
+- The **Validation Harness** tests public interfaces and should avoid depending on private helper names.
 
-## Example dialogue
+## Example Dialogue
 
-> **Dev:** "Chops shows `changelog-md-workmanship` under both Claude and Codex. Is that two versions?"
-> **Domain expert:** "No, that is a **Duplicate Skill** because the same skill is visible from two **Visible Skill Roots**."
-
-> **Dev:** "Where should `changelog-md-workmanship` live if both Claude and Codex can use it?"
-> **Domain expert:** "In the **Shared Skill Root**, unless one agent needs a materially different version."
-
-> **Dev:** "What if `grill-with-docs` has different content under Global and Codex?"
-> **Domain expert:** "That is **Skill Drift**, not a harmless **Duplicate Skill**."
-
-> **Dev:** "Should setup infer the correct catalog by deduplicating every old skill?"
-> **Domain expert:** "No. A **Skill Reset** starts from known sources and only re-adds selected skills."
-
-> **Dev:** "Do we need backups before rebuilding installed skill roots?"
-> **Domain expert:** "No. The sources are version controlled; the important part is clear **Symlink Routes**."
-
-> **Dev:** "Should we decide whole-directory symlinks before checking harness settings?"
-> **Domain expert:** "No. First identify the **Discovery Routes**; then choose the simplest **Symlink Routes** that do not duplicate them."
-
-> **Dev:** "`~/.codex/AGENTS.md` exists but is empty. Is that a managed rule?"
-> **Domain expert:** "No. It is a **Placeholder Asset** unless we intentionally put global Codex instructions there."
-
-> **Dev:** "A repo has `AGENTS.md` pointing at `skills/use-platform/SKILL.md`. Is that a global skill?"
-> **Domain expert:** "No. That is a **Project Harness Guide** referencing a repo-local skill."
-
-> **Dev:** "Should we audit all personal repos for `CLAUDE.md`, `AGENTS.md`, and skill references?"
-> **Domain expert:** "Yes. That is a **Workspace Harness Audit**, not an install or reset step."
-
-> **Dev:** "Is a `CLAUDE.md` or `AGENTS.md` file automatically healthy project guidance?"
-> **Domain expert:** "No. Treat long guide files as possible **Bloated Harness Guides** until they are shown to delegate cleanly."
-
-> **Dev:** "Should logs and session databases go in dotfiles with MCP settings?"
-> **Domain expert:** "No. MCP settings are **Harness Assets**; logs and sessions are **Runtime State**."
-
-> **Dev:** "Chops shows Skills, Agents, and Rules. Are we only managing skills?"
-> **Domain expert:** "No. Skills are one kind of **Harness Asset** in the broader **Asset Catalog**."
-
-> **Dev:** "Should `shared/` be scanned directly by agents?"
-> **Domain expert:** "No. `shared/` is the **Shared Asset Source**; agents and Chops should scan **Harness Views**."
-
-> **Dev:** "What if private paid skills are not cloned on a new machine?"
-> **Domain expert:** "The **Optional Private Source** is skipped without error, so those skills are simply unavailable."
-
-> **Dev:** "Should Chops scan source folders like `shared/`?"
-> **Domain expert:** "No. The **Chops View** should reflect the same **Harness Views** exposed to Claude, Codex, and other harnesses."
+- **Dev:** "Chops shows `changelog-md-workmanship` under both Claude and Codex. Is that two versions?"
+  **Domain expert:** "No, that is a **Duplicate Skill** because the same skill is visible from two **Visible Skill Roots**."
+- **Dev:** "Where should `changelog-md-workmanship` live if both Claude and Codex can use it?"
+  **Domain expert:** "In the **Shared Skill Root**, unless one agent needs a materially different version."
+- **Dev:** "What if `grill-with-docs` has different content under Global and Codex?"
+  **Domain expert:** "That is **Skill Drift**, not a harmless **Duplicate Skill**."
+- **Dev:** "Should setup infer the correct catalog by deduplicating every old skill?"
+  **Domain expert:** "No. A **Skill Reset** starts from known sources and only re-adds selected skills."
+- **Dev:** "Do we need backups before rebuilding installed skill roots?"
+  **Domain expert:** "No. The sources are version controlled; the important part is clear **Symlink Routes**."
+- **Dev:** "Should we decide whole-directory symlinks before checking harness settings?"
+  **Domain expert:** "No. First identify the **Discovery Routes**; then choose the simplest **Symlink Routes** that do not duplicate them."
+- **Dev:** "`~/.codex/AGENTS.md` exists but is empty. Is that a managed rule?"
+  **Domain expert:** "No. It is a **Placeholder Asset** unless we intentionally put global Codex instructions there."
+- **Dev:** "A repo has `AGENTS.md` pointing at `skills/use-platform/SKILL.md`. Is that a global skill?"
+  **Domain expert:** "No. That is a **Project Harness Guide** referencing a repo-local skill."
+- **Dev:** "Should we audit all personal repos for `CLAUDE.md`, `AGENTS.md`, and skill references?"
+  **Domain expert:** "Yes. That is a **Workspace Harness Audit**, not an install or reset step."
+- **Dev:** "Is a `CLAUDE.md` or `AGENTS.md` file automatically healthy project guidance?"
+  **Domain expert:** "No. Treat long guide files as possible **Bloated Harness Guides** until they are shown to delegate cleanly."
+- **Dev:** "Should logs and session databases go in dotfiles with MCP settings?"
+  **Domain expert:** "No. MCP settings are **Harness Assets**; logs and sessions are **Runtime State**."
+- **Dev:** "Chops shows Skills, Agents, and Rules. Are we only managing skills?"
+  **Domain expert:** "No. Skills are one kind of **Harness Asset** in the broader **Asset Catalog**."
+- **Dev:** "Should `shared/` be scanned directly by agents?"
+  **Domain expert:** "No. `shared/` is the **Shared Asset Source**; agents and Chops should scan **Harness Views**."
+- **Dev:** "What if private paid skills are not cloned on a new machine?"
+  **Domain expert:** "The **Optional Private Source** is skipped without error, so those skills are simply unavailable."
+- **Dev:** "Should Chops scan source folders like `shared/`?"
+  **Domain expert:** "No. The **Chops View** should reflect the same **Harness Views** exposed to Claude, Codex, and other harnesses."
 
 ## Flagged ambiguities
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BREWFILE_WORK := Brewfile.work
 BREWFILE_COMMON := Brewfile.common
 BREWFILE_ALL := Brewfile.all
 BREWFILE_POSIX := Brewfile.posix
-BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
+BREW_UPDATE := ./scripts/brew-update.sh
 
 define profile-brewfile
 $(if $(filter work,$1),$(BREWFILE_WORK),$(if $(filter common,$1),$(BREWFILE_COMMON),$(if $(filter all,$1),$(BREWFILE_ALL),$(BREWFILE_PERSONAL))))
@@ -112,15 +112,7 @@ personal-setup: ## Full personal Mac setup (packages + macOS settings)
 update-all: ## Update all installed tools (brew, apt, cargo, uv, mas, mise)
 	@echo "$(YELLOW)Updating all package managers and tools...$(NC)"
 	@echo ""
-	@if command -v brew >/dev/null 2>&1; then \
-		echo "$(BLUE)Updating Homebrew...$(NC)"; \
-		$(BREW_WITH_POLICY) update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
-		$(BREW_WITH_POLICY) upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
-		$(BREW_WITH_POLICY) upgrade --cask || echo "$(YELLOW)  Warning: brew cask upgrade failed (some casks may have issues)$(NC)"; \
-		$(BREW_WITH_POLICY) cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
-		echo "$(GREEN)✓ Homebrew update completed$(NC)"; \
-		echo ""; \
-	fi
+	@$(BREW_UPDATE) update-all
 	@if command -v apt-get >/dev/null 2>&1 && [ "$$(id -u)" -eq 0 ]; then \
 		echo "$(BLUE)Updating apt packages...$(NC)"; \
 		apt-get update && apt-get upgrade -y && apt-get autoremove -y; \
@@ -321,17 +313,7 @@ update: ## Update packages for the selected profile/focus/package-manager (only 
 ifneq ($(filter $(FOCUS_AREAS),$(MAKECMDGOALS)),)
 	@: # No-op if a focus target was specified
 else ifneq ($(filter brew,$(MAKECMDGOALS)),)
-	@if command -v brew >/dev/null 2>&1; then \
-		echo "$(BLUE)Updating Homebrew packages and casks...$(NC)"; \
-		$(BREW_WITH_POLICY) update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
-		$(BREW_WITH_POLICY) upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
-		$(BREW_WITH_POLICY) upgrade --cask || echo "$(YELLOW)  Warning: brew upgrade --cask failed$(NC)"; \
-		$(BREW_WITH_POLICY) cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
-		echo "$(GREEN)✓ Homebrew updated$(NC)"; \
-	else \
-		echo "$(RED)Homebrew is not installed$(NC)"; \
-		exit 1; \
-	fi
+	@$(BREW_UPDATE) package-manager
 else ifneq ($(filter cargo,$(MAKECMDGOALS)),)
 	@if command -v rustup >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating Rust toolchain...$(NC)"; \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ BREWFILE_WORK := Brewfile.work
 BREWFILE_COMMON := Brewfile.common
 BREWFILE_ALL := Brewfile.all
 BREWFILE_POSIX := Brewfile.posix
+BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
 
 define profile-brewfile
 $(if $(filter work,$1),$(BREWFILE_WORK),$(if $(filter common,$1),$(BREWFILE_COMMON),$(if $(filter all,$1),$(BREWFILE_ALL),$(BREWFILE_PERSONAL))))
@@ -113,10 +114,10 @@ update-all: ## Update all installed tools (brew, apt, cargo, uv, mas, mise)
 	@echo ""
 	@if command -v brew >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating Homebrew...$(NC)"; \
-		brew update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
-		brew upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
-		brew upgrade --cask || echo "$(YELLOW)  Warning: brew cask upgrade failed (some casks may have issues)$(NC)"; \
-		brew cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
+		$(BREW_WITH_POLICY) update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
+		$(BREW_WITH_POLICY) upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
+		$(BREW_WITH_POLICY) upgrade --cask || echo "$(YELLOW)  Warning: brew cask upgrade failed (some casks may have issues)$(NC)"; \
+		$(BREW_WITH_POLICY) cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
 		echo "$(GREEN)✓ Homebrew update completed$(NC)"; \
 		echo ""; \
 	fi
@@ -322,10 +323,10 @@ ifneq ($(filter $(FOCUS_AREAS),$(MAKECMDGOALS)),)
 else ifneq ($(filter brew,$(MAKECMDGOALS)),)
 	@if command -v brew >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating Homebrew packages and casks...$(NC)"; \
-		brew update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
-		brew upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
-		brew upgrade --cask || echo "$(YELLOW)  Warning: brew upgrade --cask failed$(NC)"; \
-		brew cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
+		$(BREW_WITH_POLICY) update || echo "$(YELLOW)  Warning: brew update failed$(NC)"; \
+		$(BREW_WITH_POLICY) upgrade || echo "$(YELLOW)  Warning: brew upgrade failed$(NC)"; \
+		$(BREW_WITH_POLICY) upgrade --cask || echo "$(YELLOW)  Warning: brew upgrade --cask failed$(NC)"; \
+		$(BREW_WITH_POLICY) cleanup || echo "$(YELLOW)  Warning: brew cleanup failed$(NC)"; \
 		echo "$(GREEN)✓ Homebrew updated$(NC)"; \
 	else \
 		echo "$(RED)Homebrew is not installed$(NC)"; \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ BREWFILE_WORK := Brewfile.work
 BREWFILE_COMMON := Brewfile.common
 BREWFILE_ALL := Brewfile.all
 BREWFILE_POSIX := Brewfile.posix
+BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
 BREW_UPDATE := ./scripts/brew-update.sh
 
 define profile-brewfile
@@ -252,7 +253,7 @@ brewfile-install: ## Install from the selected profile Brewfile (preferred)
 		$(MAKE) brewfile-generate; \
 	fi
 	@echo "$(BLUE)Installing via brew bundle: $(SELECTED_BREWFILE)$(NC)"
-	@brew bundle --file="$(SELECTED_BREWFILE)"
+	@$(BREW_WITH_POLICY) bundle --file="$(SELECTED_BREWFILE)"
 
 .PHONY: runtime-install
 runtime-install: ## Install runtimes declared in local mise.toml (project-level)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ BREW_REFRESH=true make update # Also run brew update before targeted Homebrew up
 - Force mode (`-f`) to handle existing configurations
 - Update manifests under `.generated/update-plans/` show selected tools, managers, and updatable counts
 
+## Architecture Maps
+
+The durable architecture maps live in [docs/architecture/index.html](docs/architecture/index.html).
+They document how the Makefile, Configuration Bundles, Install Manifests, package manager adapters,
+macOS profiles, Stow trees, Harness Assets, and Validation Harness fit together.
+
 ## Usage
 
 ### Package Installation and Configuration

--- a/_test/cli-contracts.bats
+++ b/_test/cli-contracts.bats
@@ -48,6 +48,18 @@ assert_help_contract() {
   done
 }
 
+@test "brew-with-policy: help documents tap trust policy without requiring Homebrew" {
+  run "$REPO_ROOT/scripts/brew-with-policy.sh" --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"Homebrew tap trust policy"* ]]
+  [[ "$output" == *"HOMEBREW_REQUIRE_TAP_TRUST"* ]]
+  [[ "$output" == *"HOMEBREW_NO_REQUIRE_TAP_TRUST"* ]]
+  [[ "$output" == *"HOMEBREW_NO_ENV_HINTS"* ]]
+  [[ "$output" == *"Examples:"* ]]
+}
+
 @test "generate-brewfile: dry-run previews output without writing the file" {
   if ! command -v yq >/dev/null 2>&1; then
     skip "yq is required for manifest generation tests"

--- a/_test/install.bats
+++ b/_test/install.bats
@@ -358,6 +358,8 @@ esac
 
   # shellcheck disable=SC2016  # mock script is intentionally single-quoted
   mock_command_with_script "brew" '
+printf "%s\t%s\t%s\t%s\n" "$*" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" "${HOMEBREW_NO_AUTO_UPDATE:-}" >> "'"$BATS_TEST_TMPDIR"'/brew-policy-env.txt"
+
 case "$1 $2" in
   "list --formula")
     echo "jq"
@@ -404,6 +406,8 @@ esac
   run grep -qx -- "update" "$MOCK_CALLS_DIR/brew.calls"
   [ "$status" -ne 0 ]
   assert_mock_called "brew" "upgrade jq"
+  run awk -F '\t' '$1 == "upgrade jq" && $2 == "1" && $3 == "1" && $4 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$BATS_TEST_TMPDIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
 }
 
 @test "run_brew_update can refresh Homebrew metadata when requested" {
@@ -414,6 +418,8 @@ esac
 
   # shellcheck disable=SC2016  # mock script is intentionally single-quoted
   mock_command_with_script "brew" '
+printf "%s\t%s\t%s\t%s\n" "$*" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" "${HOMEBREW_NO_AUTO_UPDATE:-}" >> "'"$BATS_TEST_TMPDIR"'/brew-policy-env.txt"
+
 case "$1 $2" in
   "list --formula")
     echo "jq"
@@ -450,6 +456,10 @@ esac
   [[ "$output" == *"Info: Refreshing Homebrew metadata..."* ]]
   assert_mock_called "brew" "update"
   assert_mock_called "brew" "upgrade jq"
+  run awk -F '\t' '$1 == "update" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$BATS_TEST_TMPDIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "upgrade jq" && $2 == "1" && $3 == "1" && $4 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$BATS_TEST_TMPDIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
 }
 
 @test "write_update_manifest records selected update tools and manager counts" {

--- a/_test/install.bats
+++ b/_test/install.bats
@@ -296,6 +296,32 @@ esac
   [ "$status" -eq 0 ]
 }
 
+@test "run_brew_install applies Homebrew tap trust policy to brew bundle" {
+  MANIFEST_BREWFILE="$BATS_TEST_TMPDIR/Brewfile"
+  cat > "$MANIFEST_BREWFILE" <<'EOF'
+brew "jq"
+EOF
+  METADATA_LINES=("jq"$'\t'"brew"$'\t'"package"$'\t'"jq --version"$'\t'"false"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'"")
+
+  # shellcheck disable=SC2016  # mock script is intentionally single-quoted
+  mock_command_with_script "brew" '
+case "$1" in
+  bundle)
+    printf "%s\t%s\n" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" > "'"$BATS_TEST_TMPDIR"'/brew-policy-env.txt"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+'
+
+  run run_brew_install
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "1" && $2 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$BATS_TEST_TMPDIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+}
+
 @test "run_brew_install skips formulae already satisfied by install checks" {
   MANIFEST_BREWFILE="$BATS_TEST_TMPDIR/Brewfile"
   cat > "$MANIFEST_BREWFILE" <<'EOF'

--- a/_test/install.bats
+++ b/_test/install.bats
@@ -410,6 +410,25 @@ esac
   [ "$status" -eq 0 ]
 }
 
+@test "run_brew_update reports tap and skip_update entries without querying Homebrew" {
+  METADATA_LINES=(
+    "felixkratz/formulae"$'\t'"brew"$'\t'"tap"$'\t'"brew tap | grep -q felixkratz/formulae"$'\t'"false"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'""
+    "jq"$'\t'"brew"$'\t'"package"$'\t'"jq --version"$'\t'"true"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'""
+    "ghostty"$'\t'"brew"$'\t'"cask"$'\t'"ghostty --version"$'\t'"true"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"null"$'\t'"test"$'\t'""
+  )
+
+  mock_command_with_script "brew" '
+echo "unexpected brew call: $*" >&2
+exit 1
+'
+
+  run run_brew_update
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skip: Homebrew taps are managed repositories (1): felixkratz/formulae"* ]]
+  [[ "$output" == *"Skip: Homebrew updates disabled by configuration (2): jq (package), ghostty (cask)"* ]]
+  assert_mock_not_called "brew"
+}
+
 @test "run_brew_update can refresh Homebrew metadata when requested" {
   export BREW_REFRESH="true"
   METADATA_LINES=(

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -70,10 +70,12 @@ echo "generate-install-manifests called for $out_dir with: $*"
 EOF
   chmod +x scripts/generate-install-manifests.sh
 
-  if [ -f "$REPO_ROOT/scripts/brew-with-policy.sh" ]; then
-    cp "$REPO_ROOT/scripts/brew-with-policy.sh" scripts/
-    chmod +x scripts/brew-with-policy.sh
-  fi
+  for script in brew-with-policy.sh brew-update.sh; do
+    if [ -f "$REPO_ROOT/scripts/$script" ]; then
+      cp "$REPO_ROOT/scripts/$script" scripts/
+      chmod +x "scripts/$script"
+    fi
+  done
 
   # Copy the Makefile
   cp "$REPO_ROOT/Makefile" .
@@ -222,6 +224,38 @@ EOF
   run awk -F '\t' '$1 == "upgrade" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
   [ "$status" -eq 0 ]
   run awk -F '\t' '$1 == "cleanup" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "make Homebrew update targets use the shared Homebrew update module" {
+  cat > scripts/brew-update.sh <<'EOF'
+#!/usr/bin/env bash
+printf "%s\n" "$1" >> "$TEST_DIR/brew-update-calls.txt"
+echo "shared Homebrew update module: $1"
+exit 0
+EOF
+  chmod +x scripts/brew-update.sh
+
+  for command in rustup uv mas mise; do
+    cat > "$TEST_DIR/mocks/$command" <<'EOF'
+#!/usr/bin/env bash
+echo "$0 $*"
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mocks/$command"
+  done
+
+  run make brew update
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "shared Homebrew update module: package-manager" ]]
+
+  run make update-all
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "shared Homebrew update module: update-all" ]]
+
+  run grep -qx "package-manager" "$TEST_DIR/brew-update-calls.txt"
+  [ "$status" -eq 0 ]
+  run grep -qx "update-all" "$TEST_DIR/brew-update-calls.txt"
   [ "$status" -eq 0 ]
 }
 

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -127,6 +127,29 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "make brewfile-install applies Homebrew tap trust policy to brew bundle" {
+  cat > "$TEST_DIR/mocks/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "bundle" ]]; then
+  shift
+  printf "%s\n" "$@" > "${TEST_DIR}/brew-bundle-args.txt"
+  printf "%s\t%s\n" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" > "${TEST_DIR}/brew-policy-env.txt"
+  echo "brew bundle called"
+  exit 0
+fi
+echo "brew $*"
+exit 0
+EOF
+  chmod +x "$TEST_DIR/mocks/brew"
+
+  run make brewfile-install
+  [ "$status" -eq 0 ]
+  run grep -qx -- '--file=Brewfile.common' "$TEST_DIR/brew-bundle-args.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "1" && $2 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+}
+
 @test "make personal without action triggers install" {
   run make personal
   [ "$status" -eq 0 ]

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -70,6 +70,11 @@ echo "generate-install-manifests called for $out_dir with: $*"
 EOF
   chmod +x scripts/generate-install-manifests.sh
 
+  if [ -f "$REPO_ROOT/scripts/brew-with-policy.sh" ]; then
+    cp "$REPO_ROOT/scripts/brew-with-policy.sh" scripts/
+    chmod +x scripts/brew-with-policy.sh
+  fi
+
   # Copy the Makefile
   cp "$REPO_ROOT/Makefile" .
 }
@@ -171,6 +176,53 @@ teardown() {
   [[ "$output" =~ "host/personal" ]]
   [[ "$output" =~ "focus/cloud" ]]
   [[ "$output" =~ "-u" ]]
+}
+
+@test "make brew update applies Homebrew tap trust policy to brew commands" {
+  cat > "$TEST_DIR/mocks/brew" <<'EOF'
+#!/usr/bin/env bash
+printf "%s\t%s\t%s\n" "$*" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" >> "$TEST_DIR/brew-policy-env.txt"
+echo "brew $*"
+exit 0
+EOF
+  chmod +x "$TEST_DIR/mocks/brew"
+
+  run make brew update
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "update" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "upgrade" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "upgrade --cask" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "make update-all applies Homebrew tap trust policy to brew commands" {
+  cat > "$TEST_DIR/mocks/brew" <<'EOF'
+#!/usr/bin/env bash
+printf "%s\t%s\t%s\n" "$*" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" >> "$TEST_DIR/brew-policy-env.txt"
+echo "brew $*"
+exit 0
+EOF
+  chmod +x "$TEST_DIR/mocks/brew"
+
+  for command in rustup uv mas mise; do
+    cat > "$TEST_DIR/mocks/$command" <<'EOF'
+#!/usr/bin/env bash
+echo "$0 $*"
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mocks/$command"
+  done
+
+  run make update-all
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "update" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "upgrade" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$1 == "cleanup" && $2 == "1" && $3 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
 }
 
 @test "make update passes dry-run flag when requested" {

--- a/docs/architecture/config-manifest-pipeline.html
+++ b/docs/architecture/config-manifest-pipeline.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Config manifest pipeline - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Catalog module</p>
+          <h1 class="text-3xl font-semibold">Configuration bundles to install manifests</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            Configuration Bundles are YAML source. Install Manifests are the generated interface
+            consumed by install and update modules.
+          </p>
+        </div>
+      </header>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Pipeline</h2>
+        <pre class="mermaid mt-4">
+flowchart LR
+  Configs[_configs/*.yaml] --> Make[Makefile profile selection]
+  Make --> Generator[scripts/generate-install-manifests.sh]
+  Generator --> Brewfile[Brewfile]
+  Generator --> Arkade[arkade.tsv]
+  Generator --> Metadata[metadata.json]
+  Metadata --> InstallLib[scripts/install-lib.sh]
+  Brewfile --> BrewBundle[brew bundle]
+  Arkade --> ArkadeBatch[arkade get batch]
+        </pre>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Configuration Bundle</h2>
+          <p class="mt-2 text-sm text-slate-600">A bundle under <code>_configs/</code> names tools, managers, types, checks, dependencies, update behavior, descriptions, and documentation URLs.</p>
+          <p class="mt-3 font-mono text-sm">_configs/shared/shell.yaml</p>
+          <p class="font-mono text-sm">_configs/host/personal.yaml</p>
+          <p class="font-mono text-sm">_configs/focus/vscode.yaml</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Install Manifest</h2>
+          <p class="mt-2 text-sm text-slate-600">The manifest interface strips YAML shape away from execution. The engine reads rows, not config files.</p>
+          <p class="mt-3 font-mono text-sm">Brewfile</p>
+          <p class="font-mono text-sm">arkade.tsv</p>
+          <p class="font-mono text-sm">metadata.json</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Leverage</h2>
+          <p class="mt-2 text-sm text-slate-600">New managers need one manifest adapter. New bundles need no execution changes when they fit existing manager/type rows.</p>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Current depth</h2>
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div class="rounded-md border border-slate-200 p-4">
+            <p class="text-xs uppercase tracking-wider text-slate-500">Interface</p>
+            <p class="mt-2 text-sm"><code>scripts/generate-install-manifests.sh &lt;output-dir&gt; &lt;config&gt;...</code></p>
+          </div>
+          <div class="rounded-md border border-slate-200 p-4">
+            <p class="text-xs uppercase tracking-wider text-slate-500">Implementation</p>
+            <p class="mt-2 text-sm">Resolve config names, run <code>yq</code> over tools, dedupe rows, generate the three manifest adapters, and clean temp files.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/harness-asset-flow.html
+++ b/docs/architecture/harness-asset-flow.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Harness asset flow - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>.deep{background:linear-gradient(135deg,#0f172a,#1e293b);color:white}</style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Harness asset module</p>
+          <h1 class="text-3xl font-semibold">Harness asset source and discovery routes</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            Harness Assets live in source repositories and become visible through harness-specific views.
+            The implementation is intentionally cautious: discovery routes are documented before symlink routes
+            are treated as durable setup behavior.
+          </p>
+        </div>
+      </header>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Asset flow</h2>
+        <pre class="mermaid mt-4">
+flowchart LR
+  Public[public Harness Repository] --> Shared[Shared Asset Source]
+  Private[Optional Private Source] --> Sync[sync-private-harness-assets.sh]
+  Shared --> Views[Harness Views]
+  Sync --> Views
+  Views --> Claude[Claude Code discovery route]
+  Views --> Codex[Codex discovery route]
+  Views --> Global[Global Skill Root / Chops View]
+        </pre>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Shared Asset Source</h2>
+          <p class="mt-2 text-sm text-slate-600"><code>harnesses/shared/</code> is the intended public source for reusable Harness Assets. It is not the same as a live discovery route.</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Optional Private Source</h2>
+          <p class="mt-2 text-sm text-slate-600"><code>../harnesses-private</code> may contribute private skills. Absence is a normal zero-change state, not an error.</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Harness View</h2>
+          <p class="mt-2 text-sm text-slate-600"><code>agents/.agents/skills</code>, <code>claude/.claude/skills</code>, and <code>codex/.codex/skills</code> expose assets to Agent Harnesses.</p>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Safety interfaces</h2>
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div class="rounded-md border border-slate-200 p-4">
+            <p class="text-xs uppercase tracking-wider text-slate-500">sync-private-harness-assets.sh</p>
+            <p class="mt-2 text-sm text-slate-600">Interface: <code>--dry-run</code>, <code>--execute</code>, and <code>--private-root</code>. Implementation links selected private skills, detects conflicts, and respects provider load manifests.</p>
+          </div>
+          <div class="rounded-md border border-slate-200 p-4">
+            <p class="text-xs uppercase tracking-wider text-slate-500">audit-harness-guides.sh</p>
+            <p class="mt-2 text-sm text-slate-600">Interface: read-only workspace audit. Implementation scans Project Harness Guides for size and repo-local skill references.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="deep rounded-lg p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Depth rule</h2>
+        <p class="mt-3 text-sm text-slate-200">
+          A Symlink Route is useful only after a Discovery Route is known. Otherwise the setup flow can create
+          Duplicate Skills or Skill Drift while appearing to install correctly.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/homebrew-update-tap-trust.html
+++ b/docs/architecture/homebrew-update-tap-trust.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture review - n-dotfiles Homebrew path</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam-line { border-top: 2px dashed #64748b; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); color: white; }
+      .leak { color: #dc2626; border-color: #dc2626; }
+      .mass { display: grid; grid-template-columns: 88px 1fr; gap: 10px; align-items: end; }
+      .mass .face { border: 1px solid #94a3b8; background: #f8fafc; }
+      .mass .impl { border: 1px solid #475569; background: #e2e8f0; }
+      .arrow { color: #475569; font-weight: 700; }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-10">
+      <header class="space-y-5">
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Architecture review</p>
+          <h1 class="text-3xl font-semibold">n-dotfiles Homebrew update and tap-trust path</h1>
+          <p class="mt-2 text-sm text-slate-600">Generated 2026-06-01. Scope: Homebrew update, bundle, tap-trust policy, and config-driven Asset Catalog updates.</p>
+        </div>
+        <div class="grid gap-3 rounded-lg border border-slate-200 bg-white p-4 text-sm sm:grid-cols-4">
+          <div><span class="inline-block h-3 w-3 rounded-sm border border-slate-400 bg-white align-middle"></span> module</div>
+          <div><span class="inline-block w-10 align-middle seam-line"></span> seam</div>
+          <div><span class="font-semibold text-red-600">red</span> leakage</div>
+          <div><span class="inline-block h-3 w-6 rounded-sm bg-slate-900 align-middle"></span> deep module</div>
+        </div>
+      </header>
+
+      <section id="candidates" class="space-y-8">
+        <article id="tap-trust-policy-adapter" class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Homebrew tap trust policy adapter</h2>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Strong</span>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">local-substitutable</span>
+            <span class="rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-800">Implemented</span>
+          </div>
+          <div class="mt-4 grid gap-2 font-mono text-sm text-slate-700 sm:grid-cols-2">
+            <div>scripts/brew-with-policy.sh</div>
+            <div>Makefile</div>
+            <div>scripts/install-lib.sh</div>
+            <div>_test/makefile.bats, _test/install.bats, _test/cli-contracts.bats</div>
+          </div>
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Before</p>
+              <pre class="mermaid">
+flowchart TB
+  MF[Makefile callers] --> BU[brew update]
+  IL[install-lib callers] --> BG[brew bundle]
+  MF -.tap trust env.-> BU
+  IL -.tap trust env.-> BG
+  classDef leak stroke:#dc2626,stroke-width:2px,color:#dc2626;
+  class BU,BG leak
+              </pre>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">After</p>
+              <pre class="mermaid">
+flowchart TB
+  MF[Makefile callers] --> A[brew-with-policy module]
+  IL[install-lib callers] --> A
+  A --> BU[brew update]
+  A --> BG[brew bundle]
+  classDef deep fill:#0f172a,stroke:#0f172a,color:#fff;
+  class A deep
+              </pre>
+            </div>
+          </div>
+          <div class="mt-5 grid gap-4 md:grid-cols-3">
+            <p><strong>Problem.</strong> Tap-trust config leaked across callers, so the interface for each caller included Homebrew migration env.</p>
+            <p><strong>Solution.</strong> One adapter owns the tap-trust policy and callers cross that seam for mutating Homebrew commands.</p>
+            <ul class="list-disc pl-5 text-sm text-slate-700"><li>locality: policy in one module</li><li>leverage: one interface, many callers</li><li>tests cross the same seam</li></ul>
+          </div>
+        </article>
+
+        <article id="brew-bundle-policy" class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Homebrew bundle policy coverage</h2>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Strong</span>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">in-process</span>
+            <span class="rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-800">Implemented this pass</span>
+          </div>
+          <div class="mt-4 grid gap-2 font-mono text-sm text-slate-700 sm:grid-cols-2">
+            <div>Makefile</div>
+            <div>scripts/install-lib.sh</div>
+            <div>_test/makefile.bats</div>
+            <div>_test/install.bats</div>
+          </div>
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Before</p>
+              <div class="space-y-3 text-sm">
+                <div class="rounded border border-slate-300 p-3">make brewfile-install</div>
+                <div class="text-center arrow">↓ raw seam</div>
+                <div class="rounded border leak p-3">brew bundle --file=Brewfile</div>
+                <div class="rounded border border-slate-300 p-3">run_brew_install</div>
+                <div class="text-center arrow">↓ raw seam</div>
+                <div class="rounded border leak p-3">brew bundle --file=manifest</div>
+              </div>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">After</p>
+              <div class="space-y-3 text-sm">
+                <div class="grid grid-cols-2 gap-3"><div class="rounded border border-slate-300 p-3">make brewfile-install</div><div class="rounded border border-slate-300 p-3">run_brew_install</div></div>
+                <div class="text-center arrow">↓ shared seam</div>
+                <div class="deep rounded p-4 text-center">brew-with-policy module</div>
+                <div class="text-center arrow">↓</div>
+                <div class="rounded border border-slate-300 p-3 text-center">brew bundle</div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 grid gap-4 md:grid-cols-3">
+            <p><strong>Problem.</strong> Bundle install still bypassed the policy adapter, so tap-trust warning behavior was not local to one module.</p>
+            <p><strong>Solution.</strong> Route both bundle callers through the existing adapter without changing their public interface.</p>
+            <ul class="list-disc pl-5 text-sm text-slate-700"><li>locality: warning policy concentrates</li><li>leverage: bundle and update align</li><li>tests observe env policy</li></ul>
+          </div>
+        </article>
+
+        <article id="makefile-homebrew-update" class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Makefile Homebrew update module</h2>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Strong</span>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">in-process</span>
+            <span class="rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-800">Implemented</span>
+          </div>
+          <div class="mt-4 grid gap-2 font-mono text-sm text-slate-700 sm:grid-cols-2">
+            <div>Makefile</div>
+            <div>scripts/brew-update.sh</div>
+            <div>_test/makefile.bats</div>
+          </div>
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Before</p>
+              <pre class="mermaid">
+sequenceDiagram
+  participant B as make brew update
+  participant A as make update-all
+  participant U as brew update
+  participant G as brew upgrade
+  participant C as brew cleanup
+  B->>U: duplicate order
+  B->>G: duplicate warnings
+  B->>C: duplicate cleanup
+  A->>U: duplicate order
+  A->>G: duplicate warnings
+  A->>C: duplicate cleanup
+              </pre>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">After</p>
+              <pre class="mermaid">
+flowchart TB
+  B[make brew update] --> M[brew-update module]
+  A[make update-all] --> M
+  M --> P[package-manager context]
+  M --> O[update-all context]
+  M --> W[policy adapter]
+  classDef deep fill:#0f172a,stroke:#0f172a,color:#fff;
+  class M deep
+              </pre>
+            </div>
+          </div>
+          <div class="mt-5 grid gap-4 md:grid-cols-3">
+            <p><strong>Problem.</strong> Makefile targets had a shallow interface because each carried Homebrew ordering, warnings, and optionality.</p>
+            <p><strong>Solution.</strong> The caller selects a context; the module owns the implementation sequence.</p>
+            <ul class="list-disc pl-5 text-sm text-slate-700"><li>locality: ordering in one module</li><li>leverage: two callers, one seam</li><li>tests verify context behavior</li></ul>
+          </div>
+        </article>
+
+        <article id="config-brew-update-plan" class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Config-driven Homebrew update plan</h2>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Strong</span>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">in-process</span>
+            <span class="rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-800">Implemented</span>
+          </div>
+          <div class="mt-4 grid gap-2 font-mono text-sm text-slate-700 sm:grid-cols-2">
+            <div>scripts/install-lib.sh</div>
+            <div>_test/install.bats</div>
+            <div>_configs/*.yaml</div>
+          </div>
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Before</p>
+              <div class="mass">
+                <div class="face h-28 rounded p-2 text-xs">interface: all entries query brew</div>
+                <div class="impl h-32 rounded p-2 text-xs">implementation: classify tap, skip_update, package, cask, inventory, outdated, execute</div>
+              </div>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">After</p>
+              <div class="mass">
+                <div class="face h-12 rounded p-2 text-xs">interface: update plan</div>
+                <div class="impl h-40 rounded p-2 text-xs deep">implementation: classify Asset Catalog entries, probe only candidates, execute selected upgrades</div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 grid gap-4 md:grid-cols-3">
+            <p><strong>Problem.</strong> Config-only entries forced callers through inventory probes, weakening locality around Asset Catalog semantics.</p>
+            <p><strong>Solution.</strong> Prepare an update plan first; execute only formula and cask candidates that need Homebrew state.</p>
+            <ul class="list-disc pl-5 text-sm text-slate-700"><li>locality: classification first</li><li>leverage: fewer Homebrew probes</li><li>tests hit public update seam</li></ul>
+          </div>
+        </article>
+
+        <article id="remaining-risk" class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Remaining raw Homebrew read calls</h2>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">Speculative</span>
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">local-substitutable</span>
+          </div>
+          <div class="mt-4 grid gap-2 font-mono text-sm text-slate-700 sm:grid-cols-2">
+            <div>scripts/install-lib.sh: brew list/outdated</div>
+            <div>scripts/audit-installed.sh: brew list</div>
+            <div>_test/debug/check-brew.sh</div>
+          </div>
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Current</p>
+              <pre class="mermaid">
+flowchart LR
+  P[update plan] --> L[brew list]
+  P --> O[brew outdated]
+  A[audit module] --> R[brew list versions]
+  D[debug script] --> V[brew update --verbose]
+              </pre>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4">
+              <p class="mb-3 text-xs uppercase tracking-wider text-slate-500">Possible later</p>
+              <pre class="mermaid">
+flowchart LR
+  P[update plan] --> I[Homebrew inventory module]
+  A[audit module] --> I
+  D[debug script] --> X[debug-only raw command]
+  I --> L[brew read commands]
+  classDef deep fill:#0f172a,stroke:#0f172a,color:#fff;
+  class I deep
+              </pre>
+            </div>
+          </div>
+          <div class="mt-5 grid gap-4 md:grid-cols-3">
+            <p><strong>Problem.</strong> Read-only Homebrew calls are still spread across modules, but the update/tap-trust behavior does not currently leak through them.</p>
+            <p><strong>Solution.</strong> Defer a Homebrew inventory module until a second caller needs the same read semantics.</p>
+            <ul class="list-disc pl-5 text-sm text-slate-700"><li>locality: not yet worth it</li><li>leverage: currently low</li><li>one adapter is hypothetical</li></ul>
+          </div>
+        </article>
+      </section>
+
+      <section id="top-recommendation" class="rounded-lg border border-emerald-200 bg-emerald-50 p-6">
+        <p class="text-xs uppercase tracking-wider text-emerald-700">Top recommendation</p>
+        <h2 class="mt-1 text-2xl font-semibold">Stop the loop for this path.</h2>
+        <p class="mt-3 text-slate-700">The productive change was <a class="font-medium text-emerald-800 underline" href="#brew-bundle-policy">Homebrew bundle policy coverage</a>. After that, the update/tap-trust path has one policy adapter, one Makefile update module, and one config-driven update plan. Remaining raw Homebrew reads are speculative until a real second adapter appears.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture maps - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-5xl px-6 py-10 space-y-8">
+      <header class="space-y-3">
+        <p class="text-xs uppercase tracking-wider text-slate-500">Architecture maps</p>
+        <h1 class="text-3xl font-semibold">n-dotfiles: how the codebase works</h1>
+        <p class="max-w-3xl text-sm text-slate-600">
+          These documents map the main modules, interfaces, seams, and adapters in the repository.
+          They use the same architecture vocabulary as the review reports: module, interface,
+          implementation, depth, seam, adapter, leverage, and locality.
+        </p>
+      </header>
+
+      <section class="grid gap-4 md:grid-cols-2">
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="makefile-entrypoints.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Entrypoints</p>
+          <h2 class="mt-2 text-lg font-semibold">Makefile profile and action router</h2>
+          <p class="mt-2 text-sm text-slate-600">How profile, action, and focus targets select the next module.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="config-manifest-pipeline.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Catalog</p>
+          <h2 class="mt-2 text-lg font-semibold">Configuration bundles to install manifests</h2>
+          <p class="mt-2 text-sm text-slate-600">How YAML bundles become Brewfile, arkade.tsv, and metadata.json.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="install-update-execution.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Execution</p>
+          <h2 class="mt-2 text-lg font-semibold">Install and update engine</h2>
+          <p class="mt-2 text-sm text-slate-600">How install.sh executes manager-specific adapters from one manifest interface.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="homebrew-update-tap-trust.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Homebrew</p>
+          <h2 class="mt-2 text-lg font-semibold">Homebrew update and tap trust path</h2>
+          <p class="mt-2 text-sm text-slate-600">The promoted review report for Homebrew policy and update depth.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="macos-stow-setup.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Host state</p>
+          <h2 class="mt-2 text-lg font-semibold">macOS, setup, and Stow flows</h2>
+          <p class="mt-2 text-sm text-slate-600">How machine state is applied without mixing package and dotfile interfaces.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="test-validation-harness.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Validation</p>
+          <h2 class="mt-2 text-lg font-semibold">Test and validation harness</h2>
+          <p class="mt-2 text-sm text-slate-600">How Bats, mocks, shellcheck, and smoke tests protect public interfaces.</p>
+        </a>
+
+        <a class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" href="harness-asset-flow.html">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Harness assets</p>
+          <h2 class="mt-2 text-lg font-semibold">Harness asset source and discovery routes</h2>
+          <p class="mt-2 text-sm text-slate-600">How public, private, and harness-specific assets are exposed without duplication.</p>
+        </a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/install-update-execution.html
+++ b/docs/architecture/install-update-execution.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Install and update execution - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>.deep{background:linear-gradient(135deg,#0f172a,#1e293b);color:white}</style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Execution module</p>
+          <h1 class="text-3xl font-semibold">Install and update engine</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            <code>install.sh</code> is a thin interface. <code>scripts/install-lib.sh</code> holds the implementation:
+            manifest generation, availability detection, manager adapters, update plans, Stow, and reporting.
+          </p>
+        </div>
+      </header>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Execution sequence</h2>
+        <pre class="mermaid mt-4">
+sequenceDiagram
+  participant User
+  participant Install as install.sh
+  participant Lib as install-lib.sh
+  participant Gen as generate-install-manifests.sh
+  participant Managers as manager adapters
+  User->>Install: ./install.sh --update -c focus/vscode
+  Install->>Lib: parse flags and call main
+  Lib->>Gen: generate manifests
+  Gen-->>Lib: Brewfile, arkade.tsv, metadata.json
+  Lib->>Lib: load metadata and available managers
+  Lib->>Managers: run update or install phases
+  Lib-->>User: structured Info/Skip/Change output
+        </pre>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-2">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Install path</h2>
+          <div class="mt-3 space-y-2 text-sm text-slate-600">
+            <p><strong>Interface.</strong> <code>./install.sh [-c bundle] [-d] [-s] [-f]</code>.</p>
+            <p><strong>Implementation.</strong> Generate manifests, run <code>brew bundle</code>, batch <code>arkade get</code>, run direct manager adapters, apply apt fallback, then optionally Stow.</p>
+            <p><strong>Locality.</strong> Manager command details live in manager adapters, not in YAML bundles or Makefile callers.</p>
+          </div>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Update path</h2>
+          <div class="mt-3 space-y-2 text-sm text-slate-600">
+            <p><strong>Interface.</strong> <code>./install.sh --update</code> updates selected installed tools and skips missing tools.</p>
+            <p><strong>Implementation.</strong> Build update plans from metadata, respect <code>skip_update</code>, write update manifests, and run manager-specific update adapters.</p>
+            <p><strong>Leverage.</strong> One metadata row shape drives Homebrew, arkade, VSCode, mas, cargo, uv, mise, apt, and manual reporting.</p>
+          </div>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Manager adapters</h2>
+        <div class="mt-4 grid gap-3 md:grid-cols-4">
+          <div class="deep rounded-md p-3 text-sm">Homebrew bundle and update plan</div>
+          <div class="rounded-md border border-slate-200 p-3 text-sm">arkade batch install/refresh</div>
+          <div class="rounded-md border border-slate-200 p-3 text-sm">VSCode extension install/update</div>
+          <div class="rounded-md border border-slate-200 p-3 text-sm">direct managers: apt, cargo, uv, mise, mas</div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/macos-stow-setup.html
+++ b/docs/architecture/macos-stow-setup.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>macOS Stow setup - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Host state modules</p>
+          <h1 class="text-3xl font-semibold">macOS, setup, and Stow flows</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            Package installation, macOS defaults, and dotfile symlinks are separate modules with separate interfaces.
+            The setup scripts compose them for fresh or profile-specific machines.
+          </p>
+        </div>
+      </header>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Fresh host flow</h2>
+        <pre class="mermaid mt-4">
+flowchart LR
+  Bootstrap[bootstrap.sh] --> Essential[Homebrew, yq, stow, mise]
+  Essential --> MakeInstall[make install]
+  MakeInstall --> Stow[make personal stow]
+  Stow --> Macos[make personal configure]
+  Macos --> Optional[VSCode, Neovim, SSH setup]
+        </pre>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">macOS Profile</h2>
+          <p class="mt-2 text-sm text-slate-600">The interface is <code>_macos/macos.sh [profile.yaml]</code>. YAML sections map to defaults domains and restart actions.</p>
+          <p class="mt-3 font-mono text-sm">_macos/personal.yaml</p>
+          <p class="font-mono text-sm">_macos/work.yaml</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Stow Tree</h2>
+          <p class="mt-2 text-sm text-slate-600">Directories such as <code>zsh/</code>, <code>git/</code>, <code>nvim/</code>, and <code>kitty/</code> are modules whose implementation is GNU Stow layout.</p>
+          <p class="mt-3 font-mono text-sm">run_stow in scripts/install-lib.sh</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Setup Flow</h2>
+          <p class="mt-2 text-sm text-slate-600"><code>setup-personal-mac.sh</code> and work setup scripts compose bootstrap, packages, macOS settings, Stow, VSCode, and SSH setup with skip flags.</p>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Why this stays separate</h2>
+        <div class="mt-4 grid gap-4 md:grid-cols-3">
+          <p class="text-sm text-slate-600"><strong>Locality.</strong> macOS defaults logic lives in <code>_macos/</code>, not in package configs.</p>
+          <p class="text-sm text-slate-600"><strong>Leverage.</strong> Stow can run with <code>CONFIG_FILES="" ./install.sh -s</code> when packages are irrelevant.</p>
+          <p class="text-sm text-slate-600"><strong>Seam.</strong> Setup scripts compose modules but do not own their implementation.</p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/makefile-entrypoints.html
+++ b/docs/architecture/makefile-entrypoints.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Makefile entrypoints - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); color: white; }
+      .seam { border-top: 2px dashed #64748b; }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Entrypoint module</p>
+          <h1 class="text-3xl font-semibold">Makefile profile and action router</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            The Makefile is the first seam most callers cross. Its interface is profile plus action,
+            while its implementation selects config bundles and delegates to deeper shell modules.
+          </p>
+        </div>
+      </header>
+
+      <section class="grid gap-4 lg:grid-cols-2">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <div class="flex items-center gap-2">
+            <h2 class="mr-auto text-xl font-semibold">Current call graph</h2>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs text-emerald-800">Deep</span>
+          </div>
+          <pre class="mermaid mt-4">
+flowchart TB
+  User[caller: make work update] --> Router[Makefile router]
+  Router --> Profile[profile-configs]
+  Router --> Action[action target]
+  Action --> Install[install.sh]
+  Action --> Macos[_macos/macos.sh]
+  Action --> Stow[install.sh -s]
+  Action --> BrewUpdate[scripts/brew-update.sh]
+          </pre>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-xl font-semibold">Interface and implementation</h2>
+          <div class="mt-4 grid gap-3">
+            <div class="rounded-md border border-slate-200 p-3">
+              <p class="text-xs uppercase tracking-wider text-slate-500">Interface</p>
+              <p class="mt-1 text-sm">Profiles: <code>common</code>, <code>personal</code>, <code>work</code>, <code>all</code>. Actions: <code>install</code>, <code>update</code>, <code>stow</code>, <code>configure</code>. Focus areas are direct config adapters.</p>
+            </div>
+            <div class="rounded-md border border-slate-200 p-3">
+              <p class="text-xs uppercase tracking-wider text-slate-500">Implementation</p>
+              <p class="mt-1 text-sm">Make variables compute <code>PROFILE_CONFIGS</code>, <code>SELECTED_BREWFILE</code>, and <code>SELECTED_MACOS_PROFILE</code>, then shell modules perform the actual work.</p>
+            </div>
+            <div class="deep rounded-md p-3">
+              <p class="text-xs uppercase tracking-wider text-slate-300">Depth</p>
+              <p class="mt-1 text-sm">Callers learn one command shape; package-manager and host-state details stay behind seams.</p>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Important seams</h2>
+        <div class="mt-4 grid gap-4 md:grid-cols-3">
+          <div>
+            <p class="font-mono text-sm">PROFILE_CONFIGS</p>
+            <p class="mt-1 text-sm text-slate-600">Maps profile words to ordered Configuration Bundles. Shared bundles come first.</p>
+          </div>
+          <div>
+            <p class="font-mono text-sm">FOCUS_AREAS</p>
+            <p class="mt-1 text-sm text-slate-600">Bypasses profile selection and sends one bundle directly to <code>install.sh</code>.</p>
+          </div>
+          <div>
+            <p class="font-mono text-sm">BREW_UPDATE</p>
+            <p class="mt-1 text-sm text-slate-600">Adapter for full Homebrew update contexts, keeping the Makefile from owning the sequence.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/test-validation-harness.html
+++ b/docs/architecture/test-validation-harness.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Validation harness - n-dotfiles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="mx-auto max-w-6xl px-6 py-10 space-y-8">
+      <header class="space-y-4">
+        <a class="text-sm text-slate-500 hover:text-slate-900" href="index.html">Architecture maps</a>
+        <div>
+          <p class="text-xs uppercase tracking-wider text-slate-500">Validation module</p>
+          <h1 class="text-3xl font-semibold">Test and validation harness</h1>
+          <p class="mt-2 max-w-3xl text-sm text-slate-600">
+            Tests exercise shell entrypoints and public interfaces through Bats, mocks, shellcheck,
+            and optional Lima smoke tests.
+          </p>
+        </div>
+      </header>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Validation flow</h2>
+        <pre class="mermaid mt-4">
+flowchart TB
+  Runner[_test/run_tests.sh] --> Bats[Bats suites]
+  Runner --> Shellcheck[_test/shellcheck.sh]
+  Bats --> Helpers[_test/helpers/mocks.bash]
+  Bats --> Makefile[_test/makefile.bats]
+  Bats --> Install[_test/install.bats]
+  Bats --> Macos[_test/macos.bats]
+  Bats --> Contracts[_test/cli-contracts.bats]
+  Smoke[_test/lima/run-posix-smoke.sh] --> Linux[Linuxbrew and POSIX path]
+        </pre>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Public interface tests</h2>
+          <p class="mt-2 text-sm text-slate-600">Makefile, install.sh, setup scripts, and generator scripts are tested through their command interface and output contracts.</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Mock adapters</h2>
+          <p class="mt-2 text-sm text-slate-600">Mocks replace external managers at the process seam: brew, arkade, mas, cargo, code, mise, yq, defaults, and stow.</p>
+        </article>
+
+        <article class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-semibold">Quality gates</h2>
+          <p class="mt-2 text-sm text-slate-600">Shellcheck protects shell syntax and portability. Lima smoke tests cover Linux paths where Homebrew is unavailable or Linuxbrew is used.</p>
+        </article>
+      </section>
+
+      <section class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 class="text-xl font-semibold">Depth signal</h2>
+        <p class="mt-3 text-sm text-slate-600">
+          A good change usually adds one behavior test at the public interface and leaves private function names free to move.
+          If a test needs many internal variables, the module is probably too shallow or the test is crossing the wrong seam.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/scripts/brew-update.sh
+++ b/scripts/brew-update.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/brew-update.sh <package-manager|update-all>
+
+Runs the repository's Homebrew update sequence for a Makefile update context.
+
+Contexts:
+  package-manager  Required Homebrew update for `make brew update`
+  update-all        Optional Homebrew update for `make update-all`
+
+Examples:
+  scripts/brew-update.sh package-manager
+  scripts/brew-update.sh update-all
+EOF
+}
+
+print_color() {
+  printf "%b\n" "$1"
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+brew_with_policy="${script_dir}/brew-with-policy.sh"
+
+green='\033[0;32m'
+yellow='\033[1;33m'
+blue='\033[0;34m'
+red='\033[0;31m'
+nc='\033[0m'
+
+context="${1:-}"
+case "$context" in
+  package-manager)
+    require_brew=true
+    heading="Updating Homebrew packages and casks..."
+    cask_warning="  Warning: brew upgrade --cask failed"
+    success="\342\234\223 Homebrew updated"
+    trailing_blank=false
+    ;;
+  update-all)
+    require_brew=false
+    heading="Updating Homebrew..."
+    cask_warning="  Warning: brew cask upgrade failed (some casks may have issues)"
+    success="\342\234\223 Homebrew update completed"
+    trailing_blank=true
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v brew >/dev/null 2>&1; then
+  if [[ "$require_brew" == "true" ]]; then
+    print_color "${red}Homebrew is not installed${nc}"
+    exit 1
+  fi
+  exit 0
+fi
+
+print_color "${blue}${heading}${nc}"
+"$brew_with_policy" update || print_color "${yellow}  Warning: brew update failed${nc}"
+"$brew_with_policy" upgrade || print_color "${yellow}  Warning: brew upgrade failed${nc}"
+"$brew_with_policy" upgrade --cask || print_color "${yellow}${cask_warning}${nc}"
+"$brew_with_policy" cleanup || print_color "${yellow}  Warning: brew cleanup failed${nc}"
+print_color "${green}${success}${nc}"
+
+if [[ "$trailing_blank" == "true" ]]; then
+  echo ""
+fi

--- a/scripts/brew-with-policy.sh
+++ b/scripts/brew-with-policy.sh
@@ -11,6 +11,11 @@ The adapter keeps Homebrew's current default of allowing non-official taps
 unless the caller has explicitly configured tap trust, and hides repeated tap
 trust migration hints during update paths.
 
+Policy:
+  HOMEBREW_NO_ENV_HINTS=1 is applied to reduce repeated policy hints.
+  HOMEBREW_NO_REQUIRE_TAP_TRUST=1 is applied unless the caller has already set
+  HOMEBREW_REQUIRE_TAP_TRUST or HOMEBREW_NO_REQUIRE_TAP_TRUST.
+
 Examples:
   scripts/brew-with-policy.sh update
   scripts/brew-with-policy.sh upgrade --cask

--- a/scripts/brew-with-policy.sh
+++ b/scripts/brew-with-policy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/brew-with-policy.sh <brew arguments...>
+
+Runs brew with the repository's Homebrew tap trust policy.
+
+The adapter keeps Homebrew's current default of allowing non-official taps
+unless the caller has explicitly configured tap trust, and hides repeated tap
+trust migration hints during update paths.
+
+Examples:
+  scripts/brew-with-policy.sh update
+  scripts/brew-with-policy.sh upgrade --cask
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+homebrew_policy_env=(HOMEBREW_NO_ENV_HINTS=1)
+
+if [[ -z "${HOMEBREW_REQUIRE_TAP_TRUST:-}" && -z "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" ]]; then
+  homebrew_policy_env+=(HOMEBREW_NO_REQUIRE_TAP_TRUST=1)
+fi
+
+exec env "${homebrew_policy_env[@]}" brew "$@"

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -1347,7 +1347,7 @@ run_brew_install() {
   change "Homebrew bundle applied"
 }
 
-queue_brew_updates() {
+prepare_brew_update_plan() {
   BREW_UPDATE_FORMULAS=()
   BREW_UPDATE_CASKS=()
   MAS_UPDATE_LINES=()
@@ -1358,6 +1358,8 @@ queue_brew_updates() {
   local outdated_casks=""
   local line
   local tool manager type check_command skip_update extension_id
+  local -a candidate_formulas=()
+  local -a candidate_casks=()
   local -a managed_taps=()
   local -a update_disabled=()
   local -a up_to_date_formulas=()
@@ -1365,15 +1367,6 @@ queue_brew_updates() {
   local -a not_installed_formulas=()
   local -a not_installed_casks=()
   local -a unsupported_types=()
-
-  if ! command_exists "brew"; then
-    return 0
-  fi
-
-  installed_formulas=$(brew list --formula 2>/dev/null || true)
-  installed_casks=$(brew list --cask 2>/dev/null || true)
-  outdated_formulas=$(brew outdated --formula 2>/dev/null || true)
-  outdated_casks=$(brew outdated --cask 2>/dev/null || true)
 
   for line in "${METADATA_LINES[@]:-}"; do
     IFS=$'\t' read -r tool manager type check_command skip_update _ extension_id _ _ _ _ _ <<<"$line"
@@ -1399,32 +1392,50 @@ queue_brew_updates() {
 
     case "$type" in
     package)
-      if echo "$installed_formulas" | grep -qx "$tool"; then
-        if echo "$outdated_formulas" | grep -qx "$tool"; then
-          BREW_UPDATE_FORMULAS+=("$tool")
-        else
-          up_to_date_formulas+=("$tool")
-        fi
-      else
-        not_installed_formulas+=("$tool")
-      fi
+      candidate_formulas+=("$tool")
       ;;
     cask)
-      if echo "$installed_casks" | grep -qx "$tool"; then
-        if echo "$outdated_casks" | grep -qx "$tool"; then
-          BREW_UPDATE_CASKS+=("$tool")
-        else
-          up_to_date_casks+=("$tool")
-        fi
-      else
-        not_installed_casks+=("$tool")
-      fi
+      candidate_casks+=("$tool")
       ;;
     *)
       unsupported_types+=("$tool ($type)")
       ;;
     esac
   done
+
+  if command_exists "brew"; then
+    if [[ ${#candidate_formulas[@]} -gt 0 ]]; then
+      installed_formulas=$(brew list --formula 2>/dev/null || true)
+      outdated_formulas=$(brew outdated --formula 2>/dev/null || true)
+      for tool in "${candidate_formulas[@]}"; do
+        if echo "$installed_formulas" | grep -qx "$tool"; then
+          if echo "$outdated_formulas" | grep -qx "$tool"; then
+            BREW_UPDATE_FORMULAS+=("$tool")
+          else
+            up_to_date_formulas+=("$tool")
+          fi
+        else
+          not_installed_formulas+=("$tool")
+        fi
+      done
+    fi
+
+    if [[ ${#candidate_casks[@]} -gt 0 ]]; then
+      installed_casks=$(brew list --cask 2>/dev/null || true)
+      outdated_casks=$(brew outdated --cask 2>/dev/null || true)
+      for tool in "${candidate_casks[@]}"; do
+        if echo "$installed_casks" | grep -qx "$tool"; then
+          if echo "$outdated_casks" | grep -qx "$tool"; then
+            BREW_UPDATE_CASKS+=("$tool")
+          else
+            up_to_date_casks+=("$tool")
+          fi
+        else
+          not_installed_casks+=("$tool")
+        fi
+      done
+    fi
+  fi
 
   if [[ ${#up_to_date_formulas[@]} -gt 0 ]]; then
     skip "$(counted_noun "${#up_to_date_formulas[@]}" "Homebrew formula" "Homebrew formulae") already up to date"
@@ -1461,69 +1472,95 @@ queue_brew_updates() {
   fi
 }
 
-run_brew_update() {
-  if ! command_exists "brew"; then
+brew_update_plan_has_upgrades() {
+  [[ ${#BREW_UPDATE_FORMULAS[@]} -gt 0 || ${#BREW_UPDATE_CASKS[@]} -gt 0 ]]
+}
+
+run_brew_metadata_refresh_for_update_plan() {
+  if [[ "$BREW_REFRESH" != "true" ]]; then
+    skip "Homebrew metadata refresh skipped; run 'make brew update' separately or set BREW_REFRESH=true"
     return 0
   fi
 
   local started_at
   local elapsed
 
-  queue_brew_updates
-
-  if [[ ${#BREW_UPDATE_FORMULAS[@]} -eq 0 && ${#BREW_UPDATE_CASKS[@]} -eq 0 ]]; then
+  info "Refreshing Homebrew metadata..."
+  if is_dry_run; then
+    info "Would execute: brew update"
     return 0
   fi
 
-  if [[ "$BREW_REFRESH" == "true" ]]; then
-    info "Refreshing Homebrew metadata..."
-    if is_dry_run; then
-      info "Would execute: brew update"
-    else
-      started_at=$(timestamp_now)
-      run_brew_with_policy update
-      if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
-        error "brew update failed"
-        return "$CAPTURE_EXIT_CODE"
-      fi
-      elapsed=$(duration_since "$started_at")
-      info "Refreshed Homebrew metadata in $elapsed"
-    fi
-  else
-    skip "Homebrew metadata refresh skipped; run 'make brew update' separately or set BREW_REFRESH=true"
+  started_at=$(timestamp_now)
+  run_brew_with_policy update
+  if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
+    error "brew update failed"
+    return "$CAPTURE_EXIT_CODE"
+  fi
+  elapsed=$(duration_since "$started_at")
+  info "Refreshed Homebrew metadata in $elapsed"
+}
+
+run_brew_upgrade_batch_for_update_plan() {
+  local update_kind=$1
+  shift
+
+  local -a tools=("$@")
+  if [[ ${#tools[@]} -eq 0 ]]; then
+    return 0
   fi
 
-  if [[ ${#BREW_UPDATE_FORMULAS[@]} -gt 0 ]]; then
-    info "Updating $(counted_noun "${#BREW_UPDATE_FORMULAS[@]}" "Homebrew formula" "Homebrew formulae")..."
-    if is_dry_run; then
-      info "Would execute: brew upgrade $(join_by_space "${BREW_UPDATE_FORMULAS[@]}")"
-    else
-      started_at=$(timestamp_now)
-      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 "$BREW_WITH_POLICY" upgrade "${BREW_UPDATE_FORMULAS[@]}"
-      if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
-        error "brew formula upgrade failed"
-        return "$CAPTURE_EXIT_CODE"
-      fi
-      elapsed=$(duration_since "$started_at")
-      change "Updated $(counted_noun "${#BREW_UPDATE_FORMULAS[@]}" "Homebrew formula" "Homebrew formulae"): $(format_compact_list 10 "${BREW_UPDATE_FORMULAS[@]}") in $elapsed"
-    fi
+  local -a brew_args=("upgrade")
+  local noun_singular
+  local noun_plural
+  local failure_message
+
+  case "$update_kind" in
+  formula)
+    noun_singular="Homebrew formula"
+    noun_plural="Homebrew formulae"
+    failure_message="formula upgrade"
+    ;;
+  cask)
+    brew_args+=("--cask")
+    noun_singular="Homebrew cask"
+    noun_plural="Homebrew casks"
+    failure_message="cask upgrade"
+    ;;
+  *)
+    error "unsupported Homebrew update plan kind: $update_kind"
+    return 1
+    ;;
+  esac
+
+  info "Updating $(counted_noun "${#tools[@]}" "$noun_singular" "$noun_plural")..."
+  if is_dry_run; then
+    info "Would execute: brew $(join_by_space "${brew_args[@]}" "${tools[@]}")"
+    return 0
   fi
 
-  if [[ ${#BREW_UPDATE_CASKS[@]} -gt 0 ]]; then
-    info "Updating $(counted_noun "${#BREW_UPDATE_CASKS[@]}" "Homebrew cask")..."
-    if is_dry_run; then
-      info "Would execute: brew upgrade --cask $(join_by_space "${BREW_UPDATE_CASKS[@]}")"
-    else
-      started_at=$(timestamp_now)
-      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 "$BREW_WITH_POLICY" upgrade --cask "${BREW_UPDATE_CASKS[@]}"
-      if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
-        error "brew cask upgrade failed"
-        return "$CAPTURE_EXIT_CODE"
-      fi
-      elapsed=$(duration_since "$started_at")
-      change "Updated $(counted_noun "${#BREW_UPDATE_CASKS[@]}" "Homebrew cask"): $(format_compact_list 10 "${BREW_UPDATE_CASKS[@]}") in $elapsed"
-    fi
+  local started_at
+  local elapsed
+  started_at=$(timestamp_now)
+  run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 "$BREW_WITH_POLICY" "${brew_args[@]}" "${tools[@]}"
+  if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
+    error "brew $failure_message failed"
+    return "$CAPTURE_EXIT_CODE"
   fi
+  elapsed=$(duration_since "$started_at")
+  change "Updated $(counted_noun "${#tools[@]}" "$noun_singular" "$noun_plural"): $(format_compact_list 10 "${tools[@]}") in $elapsed"
+}
+
+run_brew_update() {
+  prepare_brew_update_plan
+
+  if ! brew_update_plan_has_upgrades; then
+    return 0
+  fi
+
+  run_brew_metadata_refresh_for_update_plan || return 1
+  run_brew_upgrade_batch_for_update_plan "formula" "${BREW_UPDATE_FORMULAS[@]}" || return 1
+  run_brew_upgrade_batch_for_update_plan "cask" "${BREW_UPDATE_CASKS[@]}" || return 1
 }
 
 run_mas_update() {

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -1335,9 +1335,9 @@ run_brew_install() {
   fi
 
   if [[ ${#BREW_BUNDLE_SKIP_ENV[@]} -gt 0 ]]; then
-    run_and_capture env "${BREW_BUNDLE_SKIP_ENV[@]}" brew bundle --file="$MANIFEST_BREWFILE"
+    run_and_capture env "${BREW_BUNDLE_SKIP_ENV[@]}" "$BREW_WITH_POLICY" bundle --file="$MANIFEST_BREWFILE"
   else
-    run_and_capture brew bundle --file="$MANIFEST_BREWFILE"
+    run_brew_with_policy bundle --file="$MANIFEST_BREWFILE"
   fi
   if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
     error "Homebrew bundle failed"

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -35,6 +35,7 @@ UPDATE_MANIFEST_PATH="${UPDATE_MANIFEST_PATH:-}"
 INSTALL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_REPO_ROOT="${INSTALL_REPO_ROOT:-$(cd "$INSTALL_LIB_DIR/.." && pwd)}"
 MANIFEST_GENERATOR="${MANIFEST_GENERATOR:-$INSTALL_REPO_ROOT/scripts/generate-install-manifests.sh}"
+BREW_WITH_POLICY="${BREW_WITH_POLICY:-$INSTALL_REPO_ROOT/scripts/brew-with-policy.sh}"
 
 RESOLVED_CONFIG_FILES=()
 MANIFEST_DIR=""
@@ -229,6 +230,10 @@ run_eval_and_capture() {
 
   print_captured_output "$CAPTURE_OUTPUT" "$CAPTURE_EXIT_CODE"
   return 0
+}
+
+run_brew_with_policy() {
+  run_and_capture "$BREW_WITH_POLICY" "$@"
 }
 
 can_use_apt() {
@@ -1476,7 +1481,7 @@ run_brew_update() {
       info "Would execute: brew update"
     else
       started_at=$(timestamp_now)
-      run_and_capture brew update
+      run_brew_with_policy update
       if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
         error "brew update failed"
         return "$CAPTURE_EXIT_CODE"
@@ -1494,7 +1499,7 @@ run_brew_update() {
       info "Would execute: brew upgrade $(join_by_space "${BREW_UPDATE_FORMULAS[@]}")"
     else
       started_at=$(timestamp_now)
-      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade "${BREW_UPDATE_FORMULAS[@]}"
+      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 "$BREW_WITH_POLICY" upgrade "${BREW_UPDATE_FORMULAS[@]}"
       if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
         error "brew formula upgrade failed"
         return "$CAPTURE_EXIT_CODE"
@@ -1510,7 +1515,7 @@ run_brew_update() {
       info "Would execute: brew upgrade --cask $(join_by_space "${BREW_UPDATE_CASKS[@]}")"
     else
       started_at=$(timestamp_now)
-      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade --cask "${BREW_UPDATE_CASKS[@]}"
+      run_and_capture env HOMEBREW_NO_AUTO_UPDATE=1 "$BREW_WITH_POLICY" upgrade --cask "${BREW_UPDATE_CASKS[@]}"
       if [[ $CAPTURE_EXIT_CODE -ne 0 ]]; then
         error "brew cask upgrade failed"
         return "$CAPTURE_EXIT_CODE"


### PR DESCRIPTION
## Summary
- Add durable architecture maps under `docs/architecture/` and link them from the README.
- Expand `CONTEXT.md` with the updated repository vocabulary for bundles, manifests, profiles, and harness assets.
- Refresh related Makefile, script, and contract-test coverage to match the updated setup and update flow.

## Testing
- Not run (not requested)