### PR TITLE
Harden dotfiles audits and startup paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ _reference/
 # Already tracked skills remain tracked; new local installs stay out of git.
 skills/.SKILLS_MANAGED_BY_JSM
 skills/*
+!skills/use-dotfiles/
+!skills/use-dotfiles/SKILL.md
+!skills/shell-cli-contract-audit/
+!skills/shell-cli-contract-audit/SKILL.md
 claude/.claude/skills/.SKILLS_MANAGED_BY_JSM
 claude/.claude/skills/*
 !claude/.claude/skills/.gitkeep

--- a/_test/1password.bats
+++ b/_test/1password.bats
@@ -270,6 +270,92 @@ EOF
   grep -q "private key" "$TEST_DIR/op-calls.log"
 }
 
+@test "SSH setup: unsafe private key file is restricted while op writes" {
+  cd "$TEST_DIR"
+  cp "${BATS_TEST_DIRNAME}/../setup-ssh-from-1password.sh" .
+
+  umask 022
+
+  cat > "$MOCK_BIN_DIR/sleep" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$MOCK_BIN_DIR/sleep"
+
+  cat > "$MOCK_BIN_DIR/op" <<'EOF'
+#!/bin/bash
+echo "$@" >> "$TEST_DIR/op-calls.log"
+
+file_mode() {
+  if stat -c %a "$1" >/dev/null 2>&1; then
+    stat -c %a "$1"
+  else
+    stat -f %Lp "$1"
+  fi
+}
+
+field_name=""
+previous=""
+for arg in "$@"; do
+  if [[ "$previous" == "--fields" ]]; then
+    field_name="$arg"
+    break
+  fi
+  previous="$arg"
+done
+
+if [[ "$1" == "account" ]] && [[ "$2" == "list" ]]; then
+  echo "Account ID: test-account"
+  exit 0
+fi
+
+if [[ "$1" == "item" ]] && [[ "$2" == "get" ]]; then
+  item_name="$3"
+
+  if [[ "$item_name" == "~/.ssh/config" && ( "$field_name" == "notesPlain" || "$field_name" == "notes" ) ]]; then
+    echo "Host *"
+    echo "  IdentityAgent ~/.1password/agent.sock"
+    echo "Include ~/.ssh/config.d/*.conf"
+    echo "Include ~/.ssh/config.d/*/*.conf"
+    exit 0
+  fi
+
+  if [[ "$item_name" == "~/.ssh/config.d/personal.conf" && ( "$field_name" == "notesPlain" || "$field_name" == "notes" ) ]]; then
+    echo "Host github.com"
+    echo "  HostName github.com"
+    echo "  User git"
+    echo "  IdentityFile ~/.ssh/personal_github_authentication.pub"
+    echo "  IdentitiesOnly yes"
+    exit 0
+  fi
+
+  if [[ "$field_name" == "private key" ]]; then
+    file_mode "$HOME/.ssh/$item_name" >> "$TEST_DIR/private-key-open-modes.log"
+    echo "-----BEGIN OPENSSH PRIVATE KEY-----"
+    echo "mock private key content"
+    echo "-----END OPENSSH PRIVATE KEY-----"
+    exit 0
+  fi
+
+  if [[ "$field_name" == "public key" ]]; then
+    echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN... test@example.com"
+    exit 0
+  fi
+fi
+
+echo "Unhandled op command: $@" >&2
+exit 1
+EOF
+  chmod +x "$MOCK_BIN_DIR/op"
+
+  run ./setup-ssh-from-1password.sh --profile personal --unsafe --yes --no-input
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_DIR/private-key-open-modes.log" ]
+  run grep -qx "600" "$TEST_DIR/private-key-open-modes.log"
+  [ "$status" -eq 0 ]
+}
+
 @test "SSH setup: help option shows usage" {
   cd "$TEST_DIR"
   cp "${BATS_TEST_DIRNAME}/../setup-ssh-from-1password.sh" .

--- a/_test/harness-guides.bats
+++ b/_test/harness-guides.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Tests for repo-local agent harness guide references.
+
+setup() {
+  export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+}
+
+referenced_repo_skills() {
+  local guide
+
+  for guide in AGENTS.md CLAUDE.md GEMINI.md; do
+    if [ -f "$DOTFILES_DIR/$guide" ]; then
+      grep -Eho 'skills/[A-Za-z0-9._/-]+' "$DOTFILES_DIR/$guide" 2>/dev/null \
+        | sed 's#[).,;:]*$##'
+    fi
+  done | sort -u
+}
+
+@test "project harness guides: referenced repo-local skills exist" {
+  local refs=()
+  local ref
+  local missing=()
+
+  while IFS= read -r ref; do
+    refs+=("$ref")
+    if [ ! -f "$DOTFILES_DIR/$ref" ]; then
+      missing+=("$ref")
+    fi
+  done < <(referenced_repo_skills)
+
+  [ "${#refs[@]}" -gt 0 ]
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    printf 'Missing referenced skills:\n' >&3
+    printf '  %s\n' "${missing[@]}" >&3
+    return 1
+  fi
+}
+
+@test "project harness guides: referenced repo-local skills are trackable" {
+  local ref
+  local ignored=()
+
+  while IFS= read -r ref; do
+    if git -C "$DOTFILES_DIR" check-ignore -q -- "$ref"; then
+      ignored+=("$ref")
+    fi
+  done < <(referenced_repo_skills)
+
+  if [ "${#ignored[@]}" -gt 0 ]; then
+    printf 'Ignored referenced skills:\n' >&3
+    printf '  %s\n' "${ignored[@]}" >&3
+    return 1
+  fi
+}

--- a/_test/shell-configs.bats
+++ b/_test/shell-configs.bats
@@ -277,6 +277,9 @@ EOF
 
   run grep -c '_cache_init fzf' "$DOTFILES_DIR/zsh/.zshrc"
   [ "$output" = "1" ]
+
+  run grep -c '_cache_init mise' "$DOTFILES_DIR/zsh/.zshrc"
+  [ "$output" = "1" ]
 }
 
 @test "zshrc: startup time under 125ms" {

--- a/scripts/bun.lock
+++ b/scripts/bun.lock
@@ -6,46 +6,18 @@
       "name": "dotfiles-scripts",
       "dependencies": {
         "commander": "^12.1.0",
-        "puppeteer-core": "^24.1.1",
+        "puppeteer-core": "^25.1.0",
       },
     },
   },
   "packages": {
-    "@puppeteer/browsers": ["@puppeteer/browsers@2.11.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.3", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ=="],
-
-    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
-
-    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
-
-    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
-
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.4", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^17.7.2" }, "peerDependencies": { "proxy-agent": ">=8.0.1" }, "optionalPeers": ["proxy-agent"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
-
-    "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
-
-    "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
-
-    "bare-fs": ["bare-fs@4.5.2", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw=="],
-
-    "bare-os": ["bare-os@3.6.2", "", {}, "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A=="],
-
-    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
-
-    "bare-stream": ["bare-stream@2.7.0", "", { "dependencies": { "streamx": "^2.21.0" }, "peerDependencies": { "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-buffer", "bare-events"] }, "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A=="],
-
-    "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw=="],
-
-    "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
-
-    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
-
-    "chromium-bidi": ["chromium-bidi@12.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg=="],
+    "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -55,121 +27,41 @@
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
-
-    "devtools-protocol": ["devtools-protocol@0.0.1534754", "", {}, "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ=="],
+    "devtools-protocol": ["devtools-protocol@0.0.1624250", "", {}, "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
-
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
-
-    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
-
-    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
-
-    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
-
-    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
-
-    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
-
-    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
-
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
-
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+    "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
-    "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
-
-    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
-
-    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
-
-    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
-
-    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
-
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
-
-    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
-
-    "puppeteer-core": ["puppeteer-core@24.34.0", "", { "dependencies": { "@puppeteer/browsers": "2.11.0", "chromium-bidi": "12.0.1", "debug": "^4.4.3", "devtools-protocol": "0.0.1534754", "typed-query-selector": "^2.12.0", "webdriver-bidi-protocol": "0.3.10", "ws": "^8.18.3" } }, "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg=="],
+    "puppeteer-core": ["puppeteer-core@25.1.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.4", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1624250", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
-    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
-    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
-
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "tar-fs": ["tar-fs@3.1.1", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg=="],
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
 
-    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
-
-    "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
-
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "typed-query-selector": ["typed-query-selector@2.12.0", "", {}, "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="],
-
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.3.10", "", {}, "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw=="],
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "commander": "^12.1.0",
-    "puppeteer-core": "^24.1.1"
+    "puppeteer-core": "^25.1.0"
   }
 }

--- a/setup-ssh-from-1password.sh
+++ b/setup-ssh-from-1password.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# Keep downloaded SSH material private from file creation time, before chmod runs.
+umask 077
+
 # Default values
 DRY_RUN="${DRY_RUN:-false}"
 UNSAFE_MODE="${UNSAFE_MODE:-false}"

--- a/skills/shell-cli-contract-audit/SKILL.md
+++ b/skills/shell-cli-contract-audit/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: shell-cli-contract-audit
+description: Audit n-dotfiles shell entrypoints for help text, dry-run safety, non-interactive behavior, argument parsing, and validation coverage.
+---
+
+# Shell CLI Contract Audit
+
+Use this skill when changing setup or maintenance shell entrypoints.
+
+## Contract
+
+User-facing shell entrypoints should:
+
+- Expose `--help` with examples.
+- Support `--dry-run` when they mutate machine state.
+- Provide explicit non-interactive escapes for prompts, usually `--no-input`.
+- Reject unknown options with a clear error and non-zero exit.
+- Avoid destructive operations without explicit approval.
+- Keep behavior idempotent when re-run.
+
+## Review Steps
+
+1. Read the entrypoint and any sourced library it delegates to.
+2. Check that mutating paths have a dry-run or safe preview mode.
+3. Check prompts and non-interactive execution paths.
+4. Check argument validation for missing option values and conflicting flags.
+5. Add or update Bats tests through the public command interface.
+6. Run focused Bats tests, then `./_test/shellcheck.sh`.
+
+## Related Tests
+
+- `_test/cli-contracts.bats`
+- `_test/bootstrap.bats`
+- `_test/install.bats`
+- `_test/setup-personal-mac.bats`
+- `_test/setup-work-mac.bats`
+- `_test/1password.bats`

--- a/skills/use-dotfiles/SKILL.md
+++ b/skills/use-dotfiles/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: use-dotfiles
+description: Use n-dotfiles repository conventions for setup, package catalog, macOS defaults, Stow trees, harness assets, and validation.
+---
+
+# Use n-dotfiles
+
+Use this skill when working in the n-dotfiles repository.
+
+## Workflow
+
+1. Read `AGENTS.md` and `CONTEXT.md` before changing behavior.
+2. Keep changes small, reviewable, and idempotent.
+3. Treat Git as read-only unless the user explicitly asks for commits, pushes, or branches.
+4. Prefer `--help` and `--dry-run` before mutating setup scripts.
+5. Stop and ask before running commands likely to take more than about 5 minutes.
+
+## Placement
+
+- Tool install definitions belong in `_configs/*.yaml`.
+- macOS setting changes belong in `_macos/`.
+- Dotfile content belongs in the matching Stow tree such as `zsh/`, `git/`, `nvim/`, or `kitty/`.
+- Harness asset and skill guidance should use portable relative paths.
+
+## Validation
+
+Prefer the narrowest relevant validation first:
+
+- `./install.sh --help`
+- `./install.sh --list`
+- `./bootstrap.sh --dry-run --no-input --skip-1password`
+- `./setup-personal-mac.sh --dry-run --no-input`
+- `./_test/run_tests.sh`
+- `./_test/shellcheck.sh`

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -55,17 +55,27 @@ export EDITOR="nvim"
 export SUDO_EDITOR="$EDITOR"
 export LANG="en_GB.UTF-8"
 export WORDCHARS="" # Specify word boundaries for command line navigation
+_ZSH_COMMAND_MODE=false
+[[ -o interactive && -n "${ZSH_EXECUTION_STRING:-}" ]] && _ZSH_COMMAND_MODE=true
 
 #
 # 3. Homebrew
 #
 if [[ "$OSTYPE" == "darwin"* ]]; then
   if [[ -d "/opt/homebrew" ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
     BREW_PREFIX="/opt/homebrew"
+    if [[ "$_ZSH_COMMAND_MODE" == "true" ]]; then
+      export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+    else
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
   elif [[ -d "/usr/local/Homebrew" ]]; then
-    eval "$(/usr/local/bin/brew shellenv)"
     BREW_PREFIX="/usr/local"
+    if [[ "$_ZSH_COMMAND_MODE" == "true" ]]; then
+      export PATH="/usr/local/bin:$PATH"
+    else
+      eval "$(/usr/local/bin/brew shellenv)"
+    fi
   fi
 fi
 
@@ -83,16 +93,30 @@ _cache_init() {
   local name="$1"
   local cmd="$2"
   local cache_file="$_ZSH_CACHE_DIR/$name.zsh"
+  local temp_file
+
+  if [[ "$_ZSH_COMMAND_MODE" == "true" ]]; then
+    return 0
+  fi
 
   # Generate cache if it doesn't exist
   if [[ ! -f "$cache_file" ]]; then
-    if ! eval "$cmd" >"$cache_file" 2>&1; then
+    temp_file="$(mktemp "$_ZSH_CACHE_DIR/$name.XXXXXX")" || return 1
+    if ! eval "$cmd" >"$temp_file" 2>/dev/null; then
       echo "Warning: Failed to cache $name initialization" >&2
-      rm -f "$cache_file"
+      rm -f "$temp_file"
       return 1
     fi
+    mv "$temp_file" "$cache_file"
   fi
   source "$cache_file"
+}
+
+_dedupe_path() {
+  typeset -gaU path
+  path=(${(s/:/)PATH})
+  path=(${(M)path:#?*})
+  export PATH
 }
 
 #
@@ -121,51 +145,58 @@ bindkey "^[[B" history-beginning-search-forward  # Down arrow
 #
 # 6. Completions
 #
-# Add user-managed completion directories before compinit runs.
-if [[ -d "$HOME/.docker/completions" ]]; then
-  fpath=("$HOME/.docker/completions" $fpath)
-fi
+if [[ "$_ZSH_COMMAND_MODE" != "true" ]]; then
+  # Add user-managed completion directories before compinit runs.
+  if [[ -d "$HOME/.docker/completions" ]]; then
+    fpath=("$HOME/.docker/completions" $fpath)
+  fi
 
-# -Uz ensures that compinit is loaded as a pure function according
-#  to zsh's standards, without interference from any aliases defined.
-#  Then executes it with the -i flag to ignore insecure files.
-autoload -Uz compinit && compinit -i
+  # -Uz ensures that compinit is loaded as a pure function according
+  #  to zsh's standards, without interference from any aliases defined.
+  #  Use the cache dir so `sz` also rebuilds completion metadata.
+  _ZSH_COMPDUMP="$_ZSH_CACHE_DIR/zcompdump"
+  if [[ -f "$_ZSH_COMPDUMP" ]]; then
+    autoload -Uz compinit && compinit -C -i -d "$_ZSH_COMPDUMP"
+  else
+    autoload -Uz compinit && compinit -i -d "$_ZSH_COMPDUMP"
+  fi
 
-# Docker CLI completion
-# Generate once with:
-#   mkdir -p ~/.docker/completions
-#   docker completion zsh > ~/.docker/completions/_docker
+  # Docker CLI completion
+  # Generate once with:
+  #   mkdir -p ~/.docker/completions
+  #   docker completion zsh > ~/.docker/completions/_docker
 
-# Enable bash-style completion support for tools that do not ship native zsh
-# completions.
-if command -v az >/dev/null 2>&1 || command -v tofu >/dev/null 2>&1; then
-  autoload -Uz bashcompinit && bashcompinit
-fi
+  # Enable bash-style completion support for tools that do not ship native zsh
+  # completions.
+  if command -v az >/dev/null 2>&1 || command -v tofu >/dev/null 2>&1; then
+    autoload -Uz bashcompinit && bashcompinit
+  fi
 
-# Azure CLI completion
-if [[ -n "$BREW_PREFIX" ]] && command -v az >/dev/null 2>&1; then
-  AZ_COMPLETION="$BREW_PREFIX/etc/bash_completion.d/az"
-  [ -f "$AZ_COMPLETION" ] && source "$AZ_COMPLETION"
-fi
+  # Azure CLI completion
+  if [[ -n "$BREW_PREFIX" ]] && command -v az >/dev/null 2>&1; then
+    AZ_COMPLETION="$BREW_PREFIX/etc/bash_completion.d/az"
+    [ -f "$AZ_COMPLETION" ] && source "$AZ_COMPLETION"
+  fi
 
-# OpenTofu completion
-if command -v tofu >/dev/null 2>&1; then
-  complete -o nospace -C "$(command -v tofu)" tofu
-fi
+  # OpenTofu completion
+  if command -v tofu >/dev/null 2>&1; then
+    complete -o nospace -C "$(command -v tofu)" tofu
+  fi
 
-# kubectl completion and aliases
-if command -v kubectl >/dev/null 2>&1; then
-  _cache_init kubectl "kubectl completion zsh"
-  # shellcheck disable=SC1091
-  DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Developer/personal/n-dotfiles}"
-  source "$DOTFILES_DIR/scripts/kubectl-aliases.sh"
-  # In zsh, use compdef instead of bash's complete
-  compdef _kubectl k
-fi
+  # kubectl completion and aliases
+  if command -v kubectl >/dev/null 2>&1; then
+    _cache_init kubectl "kubectl completion zsh"
+    # shellcheck disable=SC1091
+    DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Developer/personal/n-dotfiles}"
+    source "$DOTFILES_DIR/scripts/kubectl-aliases.sh"
+    # In zsh, use compdef instead of bash's complete
+    compdef _kubectl k
+  fi
 
-# GitKraken CLI completion
-if command -v gk >/dev/null 2>&1; then
-  _cache_init gk "gk completion zsh"
+  # GitKraken CLI completion
+  if command -v gk >/dev/null 2>&1; then
+    _cache_init gk "gk completion zsh"
+  fi
 fi
 
 # Local environment will be sourced later in the file
@@ -196,6 +227,11 @@ for path_entry in "${early_paths[@]}"; do
     export PATH="$path_entry:$PATH"
   fi
 done
+
+if [[ "$_ZSH_COMMAND_MODE" == "true" ]]; then
+  _dedupe_path
+  return 0
+fi
 
 #
 # 7. Tool Init
@@ -249,7 +285,7 @@ fi
 #
 # 8. Plugins
 #
-if [[ -n "$BREW_PREFIX" ]]; then
+if [[ "$_ZSH_COMMAND_MODE" != "true" && -n "$BREW_PREFIX" ]]; then
   ZSH_AUTOSUGGESTIONS="$BREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
   ZSH_SYNTAX_HIGHLIGHTING="$BREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
@@ -327,9 +363,8 @@ for path_entry in "${paths[@]}"; do
   fi
 done
 
-# De-duplicate PATH and remove empty entries
-PATH=$(echo "$PATH" | awk -v RS=: '!a[$0]++' | grep -v '^$' | paste -sd: -)
-export PATH
+# De-duplicate PATH and remove empty entries.
+_dedupe_path
 
 #
 # 13. Podman
@@ -510,7 +545,7 @@ fi
 # 17. mise (polyglot runtime manager)
 #
 if command -v mise >/dev/null 2>&1; then
-  eval "$(/opt/homebrew/bin/mise activate zsh)"
+  _cache_init mise "mise activate zsh"
 fi
 
 #


### PR DESCRIPTION
## Summary
- Add repo-local skill files and keep them trackable so harness guide references resolve in a fresh clone
- Add a Bats regression for SSH private key creation and tighten unsafe writes with `umask 077`
- Reduce zsh startup cost by caching `mise`, using a compinit cache, and skipping heavy init in command mode
- Update `puppeteer-core` to remove the vulnerable proxy dependency chain and add a harness guide audit test

## Testing
- Full Bats suite passed, including the new harness guide and SSH permission regressions
- `shellcheck` passed across shell scripts and Bats files
- `bun install --frozen-lockfile` passed and `bun audit --json` returned no advisories
- Browser-tools build smoke test passed