### PR TITLE
Document slicer-mac activation and safe service restarts

### DIFF
--- a/_test/cli-contracts.bats
+++ b/_test/cli-contracts.bats
@@ -20,6 +20,15 @@ assert_help_contract() {
   [[ "$output" == *"Examples:"* ]]
 }
 
+write_mock_slicer_mac() {
+  mkdir -p "$TEST_TMP_DIR/bin"
+  cat >"$TEST_TMP_DIR/bin/slicer-mac" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SLICER_MAC_CALL_LOG"
+EOF
+  chmod +x "$TEST_TMP_DIR/bin/slicer-mac"
+}
+
 @test "user-facing scripts expose help with examples" {
   local script
   scripts=(
@@ -46,6 +55,46 @@ assert_help_contract() {
   for script in "${scripts[@]}"; do
     assert_help_contract "$script"
   done
+}
+
+@test "restart-slicer-mac: execute restarts tray and daemon as the current user" {
+  write_mock_slicer_mac
+
+  run env \
+    PATH="$TEST_TMP_DIR/bin:$PATH" \
+    SLICER_MAC_CALL_LOG="$TEST_TMP_DIR/slicer-mac-calls.log" \
+    "$REPO_ROOT/slicer-mac/restart-slicer-mac.sh" --execute
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"slicer-mac service restart tray"* ]]
+  [[ "$output" == *"slicer-mac service restart daemon"* ]]
+
+  run cat "$TEST_TMP_DIR/slicer-mac-calls.log"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"service status tray"* ]]
+  [[ "$output" == *"service status daemon"* ]]
+  [[ "$output" == *"service restart tray"* ]]
+  [[ "$output" == *"service restart daemon"* ]]
+}
+
+@test "restart-slicer-mac: rejects sudo/root because slicer-mac services are per-user" {
+  mkdir -p "$TEST_TMP_DIR/bin"
+  cat >"$TEST_TMP_DIR/bin/id" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "-u" ]]; then
+  echo 0
+  exit 0
+fi
+command id "$@"
+EOF
+  chmod +x "$TEST_TMP_DIR/bin/id"
+
+  run env PATH="$TEST_TMP_DIR/bin:$PATH" "$REPO_ROOT/slicer-mac/restart-slicer-mac.sh" --execute
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"do not run this script with sudo"* ]]
+  [[ "$output" == *"per-user launchd services"* ]]
+  [[ "$output" == *"Run without sudo: ./restart-slicer-mac.sh --execute"* ]]
 }
 
 @test "brew-with-policy: help documents tap trust policy without requiring Homebrew" {

--- a/slicer-mac/README.md
+++ b/slicer-mac/README.md
@@ -2,6 +2,19 @@
 
 Configuration for [slicer-mac](https://slicervm.com).
 
+## Activation
+
+Slicer needs periodic license activation, roughly monthly. If Slicer starts failing
+with license or activation errors, refresh the local license:
+
+```bash
+slicer activate
+```
+
+This reads the GitHub access token from `$HOME/.slicer/gh-access-token`,
+exchanges it for a Slicer license, and writes the license to
+`$HOME/.slicer/LICENSE`.
+
 ## PATH Setup
 
 The [installation docs](https://docs.slicervm.com/mac/installation/#install-the-binaries) assume
@@ -22,6 +35,23 @@ Then re-source your shell. With it on the PATH, the binaries work as expected:
 ```bash
 slicer-mac up
 slicer-tray --url ./slicer.sock --terminal "ghostty"
+```
+
+## Service Restarts
+
+Restart slicer-mac services as your login user, not with `sudo`. These are
+per-user launchd services, and running the commands with `sudo` targets `gui/0`
+instead of your user domain.
+
+```bash
+slicer-mac service restart tray
+slicer-mac service restart daemon
+```
+
+Or use the helper:
+
+```bash
+./restart-slicer-mac.sh --execute
 ```
 
 ## Setup

--- a/slicer-mac/restart-slicer-mac.sh
+++ b/slicer-mac/restart-slicer-mac.sh
@@ -16,6 +16,7 @@ Usage: slicer-mac/restart-slicer-mac.sh [options]
 
 Restart the slicer-mac tray service, daemon, or both.
 This script defaults to dry-run mode.
+Run this as your login user, not with sudo, because these are per-user launchd services.
 
 Options:
       --daemon   Restart only the daemon service
@@ -28,9 +29,14 @@ Examples:
   slicer-mac/restart-slicer-mac.sh
   slicer-mac/restart-slicer-mac.sh --execute
   slicer-mac/restart-slicer-mac.sh --execute --daemon
+  slicer-mac/restart-slicer-mac.sh --execute --tray
 EOF
 
   exit "$exit_code"
+}
+
+current_uid() {
+  id -u
 }
 
 parse_args() {
@@ -65,6 +71,13 @@ parse_args() {
 
 main() {
   parse_args "$@"
+
+  if [[ "$(current_uid)" == "0" ]]; then
+    echo "Error: do not run this script with sudo." >&2
+    echo "slicer-mac services are per-user launchd services and must target your login user's gui domain." >&2
+    echo "Run without sudo: ./restart-slicer-mac.sh --execute" >&2
+    exit 1
+  fi
 
   if ! "$DO_TRAY" && ! "$DO_DAEMON"; then
     DO_TRAY=true


### PR DESCRIPTION
## Summary
- Add README guidance for periodic Slicer license activation and where the license token and file live
- Document restarting slicer-mac services as the login user, with a helper command
- Add a root guard to `restart-slicer-mac.sh` so it fails fast when run with `sudo`
- Expand CLI contract tests to cover the restart flow and the sudo rejection path

## Testing
- Added Bats coverage for successful tray/daemon restart execution and root-user rejection