### PR TITLE
Add host-aware Linux and Omarchy setup flows

### DIFF
--- a/Brewfile.posix
+++ b/Brewfile.posix
@@ -1,9 +1,9 @@
-# Brewfile.posix — Linux (Homebrew on Linux)
+# Brewfile.posix — optional Linux (Homebrew on Linux) layer
 #
-# Hand-maintained. Covers formulae that stay in Homebrew on Linux
-# hosts. Cross-platform CLI tools live in mise instead
-# (mise/.config/mise/config.toml), so the Linux path is:
-#   brew bundle --file Brewfile.posix && ./stow.sh && mise install
+# Hand-maintained. Covers formulae for Linux hosts that intentionally use
+# Homebrew. Cross-platform CLI tools live in mise instead
+# (mise/.config/mise/config.toml). Arch/Omarchy uses pacman for system
+# packages and should use ./setup-omarchy.sh instead.
 #
 # Apply with: brew bundle --file Brewfile.posix
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,37 @@
 #   stow          (stow.sh: symlink dotfiles into $HOME)
 #   mise install  (mise/.config/mise/config.toml: CLI tools + runtimes)
 
-# Colors for output
+# Colors for output. GNU make 4 exposes MAKE_TERMOUT when stdout is a
+# terminal. Older make versions and dumb terminals stay uncoloured so escape
+# sequences never leak into logs or redirected output. FORCE_COLOR is useful
+# when an interactive terminal is detected incorrectly by a wrapper.
+ifeq ($(strip $(NO_COLOR)),)
+ifeq ($(TERM),dumb)
+COLOR_ENABLED :=
+else ifneq ($(strip $(FORCE_COLOR)),)
+COLOR_ENABLED := 1
+else ifneq ($(strip $(MAKE_TERMOUT)),)
+COLOR_ENABLED := 1
+else
+COLOR_ENABLED :=
+endif
+else
+COLOR_ENABLED :=
+endif
+
+ifeq ($(COLOR_ENABLED),1)
 GREEN := \033[0;32m
 YELLOW := \033[1;33m
 BLUE := \033[0;34m
 RED := \033[0;31m
 NC := \033[0m
+else
+GREEN :=
+YELLOW :=
+BLUE :=
+RED :=
+NC :=
+endif
 
 BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
 BREW_UPDATE := ./scripts/brew-update.sh
@@ -18,6 +43,12 @@ BREWFILE := $(if $(filter Darwin,$(HOST_OS)),Brewfile,Brewfile.posix)
 
 # macOS settings profile for `make configure` (personal or work)
 MACOS_PROFILE ?= personal
+
+ifeq ($(HOST_OS),Darwin)
+INSTALL_TARGETS := brewfile-install stow mise-install
+else
+INSTALL_TARGETS := stow mise-install
+endif
 
 # Default target
 .DEFAULT_GOAL := help
@@ -31,21 +62,26 @@ help: ## Show this help message
 		awk 'BEGIN {FS = ":.*?## "}; /^##@/ {printf "\n$(YELLOW)%s$(NC)\n", substr($$0, 5)} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-25s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(BLUE)Typical flows:$(NC)"
-	@echo "  ./bootstrap.sh            Fresh Mac: Homebrew + Brewfile + stow + mise"
-	@echo "  make install              Re-apply Brewfile + stow + mise"
+	@if [ "$(HOST_OS)" = "Darwin" ]; then \
+		echo "  ./bootstrap.sh            Fresh Mac: Homebrew + Brewfile + stow + mise"; \
+		echo "  make install              Re-apply Brewfile + stow + mise"; \
+		echo "  make configure            Apply macOS settings (MACOS_PROFILE=personal)"; \
+	else \
+		echo "  make linux-install        Linux: stow dotfiles + install mise tools"; \
+		echo "  make omarchy-setup        Arch/Omarchy: packages + dotfiles + keyd"; \
+	fi
 	@echo "  make stow                 Symlink dotfiles only (all a work machine needs)"
 	@echo "  make update               Update brew, mise, and mas-managed tools"
-	@echo "  make configure            Apply macOS settings (MACOS_PROFILE=personal)"
 
 ##@ Install
 
 .PHONY: install
-install: brewfile-install stow mise-install ## Apply Brewfile + stow + mise (idempotent)
+install: $(INSTALL_TARGETS) ## Apply the host-appropriate package, stow, and mise layers
 
 .PHONY: brewfile-install
 brewfile-install: ## Install packages from the Brewfile (Brewfile.posix on Linux)
 	@if ! command -v brew >/dev/null 2>&1; then \
-		echo "$(RED)Homebrew is required; run ./bootstrap.sh first$(NC)"; \
+		echo "$(RED)Homebrew is required for brewfile-install; use make linux-install on Linux$(NC)"; \
 		exit 1; \
 	fi
 	@echo "$(BLUE)Installing via brew bundle: $(BREWFILE)$(NC)"
@@ -62,9 +98,21 @@ mise-install: ## Install CLI tools and runtimes declared in mise config
 		mise install; \
 		echo "$(GREEN)✓ mise tools installed$(NC)"; \
 	else \
-		echo "$(RED)mise not found; run ./bootstrap.sh or 'brew install mise'$(NC)"; \
+		echo "$(RED)mise not found; install it with the host package manager first$(NC)"; \
 		exit 1; \
 	fi
+
+.PHONY: linux-install
+linux-install: ## Install Linux dotfiles and mise tools without Homebrew
+	@if [ "$(HOST_OS)" = "Darwin" ]; then \
+		echo "$(RED)linux-install is for Linux; use make install on macOS$(NC)"; \
+		exit 1; \
+	fi
+	@$(MAKE) stow mise-install
+
+.PHONY: omarchy-setup
+omarchy-setup: ## Run the idempotent Arch/Omarchy setup flow
+	@./setup-omarchy.sh
 
 .PHONY: personal-setup
 personal-setup: ## Full personal Mac setup (bootstrap + macOS settings + SSH)
@@ -74,20 +122,22 @@ personal-setup: ## Full personal Mac setup (bootstrap + macOS settings + SSH)
 
 .PHONY: update
 update: ## Update brew packages, mise tools, and Mac App Store apps
-	@$(BREW_UPDATE) update-all
+	@if [ "$(HOST_OS)" = "Darwin" ]; then \
+		$(BREW_UPDATE) update-all; \
+	fi
 	@if command -v mise >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating mise tools and runtimes...$(NC)"; \
 		mise upgrade || echo "$(YELLOW)  Warning: mise upgrade failed$(NC)"; \
 		echo "$(GREEN)✓ mise upgrade attempted$(NC)"; \
 		echo ""; \
 	fi
-	@if command -v mas >/dev/null 2>&1; then \
+	@if [ "$(HOST_OS)" = "Darwin" ] && command -v mas >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating Mac App Store apps...$(NC)"; \
 		mas upgrade; \
 		echo "$(GREEN)✓ Mac App Store apps updated$(NC)"; \
 		echo ""; \
 	fi
-	@if command -v rustup >/dev/null 2>&1; then \
+	@if [ "$(HOST_OS)" = "Darwin" ] && command -v rustup >/dev/null 2>&1; then \
 		echo "$(BLUE)Updating Rust toolchain...$(NC)"; \
 		rustup update; \
 		echo "$(GREEN)✓ Rust updated$(NC)"; \

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Or run the whole personal flow (bootstrap + macOS settings + SSH from
 ### Existing System
 
 ```bash
-make install    # brew bundle + stow + mise install (idempotent)
+make install    # host-appropriate package layer + stow + mise (idempotent)
 make update     # update brew, mise, and Mac App Store packages
 ```
 
@@ -79,20 +79,32 @@ want to keep them — review with `git diff` afterwards.
 
 ### Linux
 
+For a general Linux host where the prerequisites are already installed:
+
 ```bash
-brew bundle --file Brewfile.posix   # Homebrew on Linux formulae
-./stow.sh                           # symlink dotfiles
-mise install                        # same CLI tools as the Mac
+make linux-install                  # symlink dotfiles + install mise tools
 ```
 
+`Brewfile.posix` remains available for Linux hosts that intentionally use
+Homebrew, but it is not part of the Arch/Omarchy path.
+
 For Omarchy/Arch, keep Omarchy's system packages and Super-key defaults, then
-layer selected Stow packages and the separate Caps-Lock Hyper bindings on top.
-See [omarchy/README.md](omarchy/README.md).
+run the dedicated idempotent setup flow:
+
+```bash
+./setup-omarchy.sh --dry-run
+./setup-omarchy.sh
+```
+
+See [omarchy/README.md](omarchy/README.md) for the package choices and
+Omarchy-specific behavior.
 
 ## Using the Makefile
 
 ```bash
-make install       # brew bundle + stow + mise install
+make install       # host-appropriate package layer + stow + mise
+make linux-install  # Linux: stow + mise, no Homebrew
+make omarchy-setup  # Arch/Omarchy: pacman prerequisites + personal layers
 make stow          # symlink dotfiles only
 make update        # update brew, mise, mas (and rustup if present)
 make configure     # apply macOS settings (MACOS_PROFILE=personal|work)

--- a/_test/cli-contracts.bats
+++ b/_test/cli-contracts.bats
@@ -34,6 +34,7 @@ EOF
   scripts=(
     "bootstrap.sh"
     "stow.sh"
+    "setup-omarchy.sh"
     "setup-personal-mac.sh"
     "setup-ssh-from-1password.sh"
     "setup-gitconfig-from-1password.sh"

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -95,10 +95,20 @@ teardown() {
   [[ "$output" =~ "Dotfile and Tool Management" ]]
 }
 
+@test "make help honors NO_COLOR and emits no ANSI escapes" {
+  run env NO_COLOR=1 make help
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033['* ]]
+}
+
 @test "make install runs brew bundle, stow, and mise install" {
   run make install
   [ "$status" -eq 0 ]
-  [[ "$output" == *"brew bundle called"* ]]
+  if [[ "$EXPECTED_BREWFILE" == "Brewfile" ]]; then
+    [[ "$output" == *"brew bundle called"* ]]
+  else
+    [[ "$output" != *"brew bundle called"* ]]
+  fi
   [[ "$output" == *"stow.sh called with:"* ]]
   [[ "$output" == *"mise install"* ]]
 }
@@ -150,11 +160,19 @@ EOF
 
   run make update
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "shared Homebrew update module: update-all" ]]
+  if [[ "$EXPECTED_BREWFILE" == "Brewfile" ]]; then
+    [[ "$output" =~ "shared Homebrew update module: update-all" ]]
+  else
+    [[ "$output" != *"shared Homebrew update module: update-all"* ]]
+  fi
   [[ "$output" =~ "mise upgrade" ]]
 
-  run grep -qx "update-all" "$TEST_DIR/brew-update-calls.txt"
-  [ "$status" -eq 0 ]
+  if [[ "$EXPECTED_BREWFILE" == "Brewfile" ]]; then
+    run grep -qx "update-all" "$TEST_DIR/brew-update-calls.txt"
+    [ "$status" -eq 0 ]
+  else
+    [ ! -f "$TEST_DIR/brew-update-calls.txt" ]
+  fi
 }
 
 @test "make configure defaults to personal macOS profile" {

--- a/_test/setup-omarchy.bats
+++ b/_test/setup-omarchy.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+setup() {
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export TEST_TMP_DIR
+  TEST_TMP_DIR="$(mktemp -d)"
+  mkdir -p "$TEST_TMP_DIR/bin" "$TEST_TMP_DIR/home"
+
+  cat >"$TEST_TMP_DIR/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "-s" ]]; then
+  echo Linux
+else
+  /usr/bin/uname "$@"
+fi
+EOF
+  chmod +x "$TEST_TMP_DIR/bin/uname"
+
+  cat >"$TEST_TMP_DIR/bin/pacman" <<'EOF'
+#!/usr/bin/env bash
+echo "pacman should not run during a dry run" >&2
+exit 1
+EOF
+  chmod +x "$TEST_TMP_DIR/bin/pacman"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP_DIR"
+}
+
+@test "setup-omarchy: dry-run previews the Arch flow without mutating" {
+  run env \
+    HOME="$TEST_TMP_DIR/home" \
+    PATH="$TEST_TMP_DIR/bin:/usr/bin:/bin" \
+    "$REPO_ROOT/setup-omarchy.sh" --dry-run --no-input
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Running in dry-run mode"* ]]
+  [[ "$output" == *"sudo pacman -S --needed --noconfirm git stow keyd mise"* ]]
+  [[ "$output" == *"Stowing personal layers: zsh nvim tmux mise codex claude agents omarchy"* ]]
+  [[ "$output" == *"Would add the Hyper bindings include"* ]]
+  [[ "$output" == *"Omarchy setup dry run complete"* ]]
+}
+
+@test "setup-omarchy: rejects unknown options" {
+  run "$REPO_ROOT/setup-omarchy.sh" --skip-vscode
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown option: --skip-vscode"* ]]
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,7 +90,7 @@ print_next_steps() {
 ensure_macos() {
   if [[ "$OSTYPE" != "darwin"* ]]; then
     error "This bootstrap script is designed for macOS only"
-    error "On Linux: brew bundle --file Brewfile.posix && ./stow.sh && mise install"
+    error "On Linux: make linux-install (or ./setup-omarchy.sh on Omarchy/Arch)"
     exit 1
   fi
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-ruby = "4.0"
-node = "lts"

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -47,9 +47,24 @@ Use a second terminal or a TTY while changing keyboard input. `keyd` has a
 panic sequence of **Backspace + Escape + Enter** if a bad mapping traps the
 keyboard.
 
+The repository provides an idempotent setup command. Preview it first; the
+real run uses `pacman` for prerequisites, stows the personal layers, installs
+the mise tools, adds the Hyprland include, and configures keyd without
+replacing Omarchy's generated files:
+
 ```bash
-# Omarchy is Arch-based; keep its package manager as the system-package owner.
-sudo pacman -S --needed git stow keyd
+./setup-omarchy.sh --dry-run
+./setup-omarchy.sh
+```
+
+The default stow set intentionally omits `git` because the tracked Git config
+points at the macOS 1Password SSH signer. Configure a Linux signer, then opt
+in explicitly with `--with-git` or run `./stow.sh git` yourself.
+
+For a manual setup, keep Omarchy's package manager as the system-package owner:
+
+```bash
+sudo pacman -S --needed git stow keyd mise
 
 git clone https://github.com/nickromney/n-dotfiles.git \
   ~/Developer/personal/n-dotfiles
@@ -61,6 +76,7 @@ cd ~/Developer/personal/n-dotfiles
 # Preview first. Select packages rather than importing every Mac-only tree.
 ./stow.sh --dry-run git zsh nvim tmux mise codex claude agents omarchy
 ./stow.sh git zsh nvim tmux mise codex claude agents omarchy
+mise install
 
 # keyd loads system configs, so expose the stowed file under a new name rather
 # than replacing any existing /etc/keyd/default.conf.

--- a/setup-omarchy.sh
+++ b/setup-omarchy.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Set up the n-dotfiles layers that belong on an Omarchy/Arch host.
+#
+# Omarchy owns the desktop and system defaults. This script only installs the
+# small Arch prerequisites needed by this repository, stows selected personal
+# layers, installs mise-managed tools, and adds the Hyper bindings include.
+
+set -euo pipefail
+
+SETUP_OMARCHY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DRY_RUN="${DRY_RUN:-false}"
+NO_INPUT="${NO_INPUT:-false}"
+WITH_GIT="${WITH_GIT:-false}"
+SKIP_KEYD="${SKIP_KEYD:-false}"
+
+usage() {
+  local exit_code=${1:-0}
+
+  cat <<EOF
+Usage: $0 [options]
+
+Set up n-dotfiles on an Omarchy/Arch Linux host without replacing Omarchy's
+managed desktop configuration.
+
+Options:
+  -d, --dry-run   Show what would happen without changing the system
+      --no-input  Pass non-interactive options to pacman
+      --with-git   Also stow the git package (review its macOS signer setting)
+      --skip-keyd  Skip the keyd link, validation, and service setup
+  -h, --help      Show this help message
+
+Examples:
+  $0 --dry-run
+  $0
+  $0 --no-input --skip-keyd
+  $0 --with-git
+
+The default stow set is: zsh nvim tmux mise codex claude agents omarchy
+Git is opt-in because the tracked git config references the macOS 1Password
+SSH signer path.
+EOF
+
+  exit "$exit_code"
+}
+
+info() {
+  echo "$*"
+}
+
+error() {
+  echo "Error: $*" >&2
+}
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf '[dry-run] Would execute:'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+
+  "$@"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -d | --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --no-input)
+        NO_INPUT=true
+        shift
+        ;;
+      --with-git)
+        WITH_GIT=true
+        shift
+        ;;
+      --skip-keyd)
+        SKIP_KEYD=true
+        shift
+        ;;
+      -h | --help)
+        usage 0
+        ;;
+      *)
+        error "Unknown option: $1"
+        usage 1
+        ;;
+    esac
+  done
+}
+
+require_linux() {
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    error "This script is for Omarchy/Arch Linux only"
+    exit 1
+  fi
+
+  if ! command -v pacman >/dev/null 2>&1; then
+    error "pacman not found; this script expects an Arch-based host"
+    exit 1
+  fi
+}
+
+install_prerequisites() {
+  local -a pacman_args=(--needed)
+  [[ "$NO_INPUT" == "true" ]] && pacman_args+=(--noconfirm)
+
+  info "Installing Arch prerequisites: git stow keyd mise"
+  run_cmd sudo pacman -S "${pacman_args[@]}" git stow keyd mise
+}
+
+stow_personal_layers() {
+  local -a packages=(zsh nvim tmux mise codex claude agents omarchy)
+  local -a stow_args=("$SETUP_OMARCHY_DIR/stow.sh")
+
+  if [[ "$WITH_GIT" == "true" ]]; then
+    packages=(git "${packages[@]}")
+    info "Including git; verify the Linux SSH signing program before committing"
+  fi
+
+  [[ "$DRY_RUN" == "true" ]] && stow_args+=(--dry-run)
+  stow_args+=("${packages[@]}")
+
+  info "Stowing personal layers: ${packages[*]}"
+  run_cmd "${stow_args[@]}"
+}
+
+install_mise_tools() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Installing mise-managed tools"
+    run_cmd mise install
+    return 0
+  fi
+
+  if ! command -v mise >/dev/null 2>&1; then
+    error "mise is still unavailable after installing Arch prerequisites"
+    exit 1
+  fi
+
+  info "Installing mise-managed tools"
+  mise install
+}
+
+ensure_hyprland_include() {
+  local bindings_file="$HOME/.config/hypr/bindings.conf"
+  local include_line='source = ~/.config/hypr/hyper.conf'
+
+  if [[ -f "$bindings_file" ]] && grep -Fqx "$include_line" "$bindings_file"; then
+    info "Hyprland Hyper bindings include already present"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Would add the Hyper bindings include to $bindings_file"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$bindings_file")"
+  if [[ -s "$bindings_file" ]]; then
+    printf '\n' >>"$bindings_file"
+  fi
+  printf '%s\n' "$include_line" >>"$bindings_file"
+  info "Added the Hyper bindings include to $bindings_file"
+}
+
+ensure_keyd() {
+  local source_file="$HOME/.config/keyd/default.conf"
+  local target_file="/etc/keyd/n-dotfiles.conf"
+
+  if [[ "$SKIP_KEYD" == "true" ]]; then
+    info "Skipping keyd setup"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Would link $target_file to $source_file"
+    run_cmd sudo keyd check "$target_file"
+    run_cmd sudo systemctl enable --now keyd
+    run_cmd sudo keyd reload
+    return 0
+  fi
+
+  if [[ ! -f "$source_file" ]]; then
+    error "Stowed keyd config not found at $source_file"
+    exit 1
+  fi
+
+  if [[ -e "$target_file" || -L "$target_file" ]]; then
+    if [[ ! -L "$target_file" || "$(readlink "$target_file")" != "$source_file" ]]; then
+      error "$target_file already exists and is not the n-dotfiles symlink"
+      error "Review it manually; refusing to overwrite Omarchy or another keyd config"
+      exit 1
+    fi
+    info "keyd config link already present"
+  else
+    sudo install -d /etc/keyd
+    sudo ln -s "$source_file" "$target_file"
+    info "Linked keyd config to $target_file"
+  fi
+
+  sudo keyd check "$target_file"
+  sudo systemctl enable --now keyd
+  sudo keyd reload
+}
+
+print_next_steps() {
+  echo
+  echo "Next steps:"
+  echo "  1. Restart the terminal so the stowed shell and mise config are active"
+  echo "  2. Run: mise ls"
+  echo "  3. Authenticate GitHub when ready: gh auth login"
+  if [[ "$WITH_GIT" != "true" ]]; then
+    echo "  4. Stow git separately after configuring a Linux SSH signer: ./stow.sh git"
+  fi
+}
+
+main() {
+  parse_args "$@"
+  require_linux
+  cd "$SETUP_OMARCHY_DIR"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Running in dry-run mode"
+  fi
+
+  install_prerequisites
+  stow_personal_layers
+  install_mise_tools
+  ensure_hyprland_include
+  ensure_keyd
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Omarchy setup dry run complete"
+  else
+    info "Omarchy setup complete"
+    print_next_steps
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add an idempotent Arch/Omarchy setup script with dry-run and safety options
- Make Makefile install and update targets host-aware, including Linux and Omarchy flows
- Document Linux package ownership and opt-in Git configuration
- Improve color handling and expand Bats coverage for platform behavior and setup contracts
- Remove the obsolete root mise configuration

## Testing
- Not run (not requested)