### PR TITLE
bootstrap-omarchy.sh: a stow conflict must not abort the rest of the script

### DIFF
--- a/_test/bootstrap-omarchy.bats
+++ b/_test/bootstrap-omarchy.bats
@@ -193,6 +193,33 @@ teardown() {
   [[ "$output" != *"WARN git:"* ]]
 }
 
+@test "bootstrap-omarchy: a stow conflict on one package does not abort the rest of the script" {
+  # Real files already at the target (e.g. Omarchy's own ~/.config/nvim) are
+  # a per-package stow conflict, not a reason to skip unrelated later steps
+  # like keyd/hypr/mise — this is what actually happened on a real run.
+  # shellcheck disable=SC2016
+  mock_command_with_script "stow" '
+for arg in "$@"; do
+  if [[ "$arg" == "nvim" ]]; then
+    echo "WARNING! stowing nvim would cause conflicts" >&2
+    exit 1
+  fi
+done
+exit 0
+'
+
+  run env \
+    HOME="$TEST_HOME" \
+    OSTYPE="linux-gnu" \
+    PATH="$MOCK_BIN_DIR:/usr/bin:/bin" \
+    "$BOOTSTRAP_SCRIPT" --no-input --skip-pacman --skip-keyd --skip-hypr --skip-mise --packages "git nvim tmux"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Stow reported conflicts"* ]]
+  [[ "$output" == *"Continuing with the rest of bootstrap"* ]]
+  [[ "$output" == *"Bootstrap complete!"* ]]
+}
+
 @test "bootstrap-omarchy: a failing mise install does not abort the rest of the script" {
   mock_command "mise" 1 ""
 

--- a/bootstrap-omarchy.sh
+++ b/bootstrap-omarchy.sh
@@ -135,11 +135,15 @@ run_stow_if_needed() {
   local -a stow_args=()
   [[ "$DRY_RUN" == "true" ]] && stow_args+=("--dry-run")
 
+  # A conflict in one package (e.g. real files already at ~/.config/nvim)
+  # must not block unrelated later steps like keyd/hypr/mise — stow.sh
+  # itself already continues past a failed package to the rest of the
+  # list, so mirror that here rather than aborting the whole bootstrap.
   # shellcheck disable=SC2086 # STOW_PACKAGES is an intentionally unquoted word list
   if ! "$BOOTSTRAP_DIR/stow.sh" "${stow_args[@]}" $STOW_PACKAGES; then
-    error "Stow reported conflicts. Existing real files are in the way."
+    error "Stow reported conflicts on one or more packages. Existing real files are in the way."
     error "Review them, then re-run './stow.sh' (or './stow.sh --adopt' to pull them into the repo — check 'git diff' afterwards)."
-    exit 1
+    error "Continuing with the rest of bootstrap; packages that failed to stow are simply not linked yet."
   fi
 }
 


### PR DESCRIPTION
## Summary

Running `bootstrap-omarchy.sh` for real on this machine surfaced this: a stow conflict on a single package (real files already at `~/.config/nvim`, since Omarchy itself populates it by default) hard-exited the whole script before it reached `keyd`, the `hyper.conf` include, `mise install`, or the 1Password check — even though those steps have nothing to do with the nvim conflict. `stow.sh` itself already continues past a failed package to the rest of its list; the bootstrap wrapper now does the same instead of treating one conflict as fatal to everything downstream.

## Test plan

- [x] `make lint` clean
- [x] `make test` 145/145 (new regression test: a stow conflict on one package still reaches "Bootstrap complete!")
- [x] Ran for real on this laptop: with the fix, the deferred `keyd` step now actually runs and completes (confirmed `keyd` enabled/active, config parsed cleanly per `journalctl -u keyd`) despite the pre-existing nvim conflict

https://claude.ai/code/session_01FJrkmALiTNUDPzMeVHnHZZ