### PR TITLE
Generate the locale that .zshrc exports

### DIFF
--- a/bootstrap-omarchy.sh
+++ b/bootstrap-omarchy.sh
@@ -21,10 +21,15 @@ OMARCHY_INSTALL_DIR="${OMARCHY_INSTALL_DIR:-$HOME/.local/share/omarchy}"
 ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-/usr/share/zsh/plugins}"
 SHELLS_FILE="${SHELLS_FILE:-/etc/shells}"
 KEYD_LINK="${KEYD_LINK:-/etc/keyd/n-dotfiles.conf}"
+LOCALE_LANG="${LOCALE_LANG:-en_GB.UTF-8}"
+# glibc reports the generated locale as "en_GB.utf8"; macOS reports
+# "en_GB.UTF-8". Match either spelling rather than assuming one.
+LOCALE_PRESENT_PATTERN="${LOCALE_PRESENT_PATTERN:-^en_GB\\.utf-?8$}"
 
 DRY_RUN="${DRY_RUN:-false}"
 NO_INPUT="${NO_INPUT:-false}"
 SKIP_PACMAN=false
+SKIP_LOCALE=false
 SKIP_STOW=false
 SKIP_SHELL=false
 SKIP_KEYD=false
@@ -47,6 +52,7 @@ Options:
   -d, --dry-run           Show what would happen without making changes
       --no-input          Disable prompts; pass --noconfirm to pacman
       --skip-pacman        Skip installing the pacman base packages
+      --skip-locale        Skip generating the system locale
       --skip-stow          Skip stowing dotfiles
       --skip-shell         Keep the account's current login shell
       --skip-keyd          Skip keyd symlink/enable/reload
@@ -146,6 +152,28 @@ load_and_validate_stow_packages() {
       exit 1
     fi
   done
+}
+
+run_locale_if_needed() {
+  if [[ "$SKIP_LOCALE" == "true" ]]; then
+    info "Skipping locale generation"
+    return 0
+  fi
+
+  # zsh/.zshrc exports LANG, and on macOS that is enough because every locale
+  # ships precompiled. glibc only has what locale-gen generated, so the same
+  # export on a fresh Arch host names a locale that does not exist. Perl then
+  # prints a 14-line warning to stderr on every invocation of any Perl-backed
+  # tool, shasum included, which is easy to mistake for a broken command.
+  if locale -a 2>/dev/null | grep -qiE "$LOCALE_PRESENT_PATTERN"; then
+    info "Locale $LOCALE_LANG already generated"
+    return 0
+  fi
+
+  info "Generating $LOCALE_LANG and setting it as the system locale..."
+  run_cmd sudo sed -i "s/^#${LOCALE_LANG} UTF-8/${LOCALE_LANG} UTF-8/" /etc/locale.gen
+  run_cmd sudo locale-gen
+  run_cmd sudo localectl set-locale "LANG=${LOCALE_LANG}"
 }
 
 run_stow_if_needed() {
@@ -421,6 +449,10 @@ parse_args() {
         SKIP_PACMAN=true
         shift
         ;;
+      --skip-locale)
+        SKIP_LOCALE=true
+        shift
+        ;;
       --skip-stow)
         SKIP_STOW=true
         shift
@@ -479,6 +511,7 @@ main() {
   run_cmd mkdir -p "$HOME/Developer/personal"
 
   run_pacman_if_needed
+  run_locale_if_needed
   run_stow_if_needed
   check_stowed_binaries
   check_zsh_plugins

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -53,7 +53,16 @@ setopt HIST_IGNORE_SPACE
 #
 export EDITOR="nvim"
 export SUDO_EDITOR="$EDITOR"
-export LANG="en_GB.UTF-8"
+# Only export a locale that actually exists. macOS ships every locale
+# precompiled, so this was safe there for years; glibc only has what locale-gen
+# generated, and naming an absent locale makes Perl-backed tools (shasum among
+# them) print a 14-line warning to stderr on every call. bootstrap-omarchy.sh
+# generates it; this guard keeps a not-yet-bootstrapped host quiet.
+# The $LANG test short-circuits the subshell once the system locale is set.
+if [[ "$LANG" != "en_GB.UTF-8" ]] &&
+  locale -a 2>/dev/null | grep -qiE '^en_GB\.utf-?8$'; then
+  export LANG="en_GB.UTF-8"
+fi
 export WORDCHARS="" # Specify word boundaries for command line navigation
 _ZSH_COMMAND_MODE=false
 [[ -o interactive && -n "${ZSH_EXECUTION_STRING:-}" ]] && _ZSH_COMMAND_MODE=true


### PR DESCRIPTION
`zsh/.zshrc` has exported `LANG="en_GB.UTF-8"` unconditionally. On macOS that is safe, because every locale ships precompiled. glibc only has what `locale-gen` generated, so on a fresh Arch host the export names a locale that does not exist, and Perl falls back to `C` with a 14-line warning to stderr **on every invocation of any Perl-backed tool**.

That is not cosmetic. `shasum` is a Perl script, and a build fingerprint that hashes each source file in turn produced **831 warning lines** in the middle of an unrelated Kubernetes apply — which reads as a broken command rather than a locale problem.

It is the same shape as the portability work in the platform repo: a macOS behaviour encoded as a portable assumption, where macOS quietly papers over a difference.

## Two changes, because there are two failures

**`bootstrap-omarchy.sh` never provisioned the locale it depends on.** New `run_locale_if_needed`, following the existing `run_X_if_needed` / `run_cmd` / `--skip-X` idiom, called from `main` next to the other sudo step. It uncomments the locale, runs `locale-gen`, and sets it with `localectl` so `/etc/locale.conf` agrees with the shell rather than disagreeing with it.

**`zsh/.zshrc` exported it unconditionally.** Now guarded, so a host that has not been bootstrapped yet stays quiet instead of warning on every command. The `$LANG` test short-circuits before the subshell, so a provisioned host pays nothing for the check.

The detection pattern matches both spellings, since glibc reports `en_GB.utf8` and macOS reports `en_GB.UTF-8`.

## Verified

```text
already generated  → "Locale en_GB.UTF-8 already generated"
not generated      → sed /etc/locale.gen → locale-gen → localectl set-locale
--skip-locale      → "Skipping locale generation"
```

The zshrc guard exports when the locale is present, and leaves `LANG` untouched when it is not. Both files pass `zsh -n` / `bash -n`; the only shellcheck finding in `bootstrap-omarchy.sh` is pre-existing at line 148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)