### PR TITLE
Make macOS setup repeatable and add AudioPriorityBar

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,16 +9,23 @@
 # Prune drift with: brew bundle cleanup --file Brewfile
 
 # Taps
-tap "FelixKratz/formulae" # borders
-tap "nikitabobko/tap" # aerospace
-tap "noahgorstein/tap" # jqp
+tap "azure/functions", trusted: { formula: "azure-functions-core-tools@4" }
+tap "dicklesworthstone/tap", trusted: { formula: "ubs" }
+tap "FelixKratz/formulae", trusted: { formula: "borders" } # borders
+tap "goreleaser/tap", trusted: { cask: "goreleaser" }
+tap "modem-dev/tap", trusted: { formula: "hunk" }
+tap "nikitabobko/tap", trusted: { cask: "aerospace" } # aerospace
+tap "noahgorstein/tap", trusted: { formula: "jqp" } # jqp
+tap "steipete/tap", trusted: { cask: "codexbar" }
 
 # Formulae
 brew "ast-grep"
 brew "bat"
 brew "borders"
 brew "bpytop"
-brew "docker"
+brew "docker", link: true
+brew "azure/functions/azure-functions-core-tools@4"
+brew "dicklesworthstone/tap/ubs"
 brew "eza"
 brew "fx"
 brew "fzf"
@@ -30,6 +37,7 @@ brew "hyperfine"
 brew "jqp"
 brew "mas"
 brew "mise"
+brew "modem-dev/tap/hunk"
 brew "ncdu"
 brew "neovim"
 brew "openssh"
@@ -37,7 +45,6 @@ brew "ranger"
 brew "sk"
 brew "sshs"
 brew "stow"
-brew "the_silver_searcher"
 brew "tmux"
 brew "visidata"
 brew "wget"
@@ -52,8 +59,9 @@ cask "1password-cli"
 cask "aerospace"
 cask "alfred"
 cask "brave-browser"
-cask "claude"
+cask "steipete/tap/codexbar"
 cask "font-jetbrains-mono-nerd-font"
+cask "goreleaser/tap/goreleaser"
 cask "ghostty"
 cask "microsoft-teams"
 cask "netnewswire"

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ NC :=
 endif
 
 BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
+BREW_BUNDLE_INSTALL := ./scripts/brew-bundle-install.sh
 BREW_UPDATE := ./scripts/brew-update.sh
 AUDIO_PRIORITY_BAR_INSTALL := ./scripts/install-audio-priority-bar.sh
 
@@ -87,7 +88,7 @@ brewfile-install: ## Install packages from the Brewfile (Brewfile.posix on Linux
 		exit 1; \
 	fi
 	@echo "$(BLUE)Installing via brew bundle: $(BREWFILE)$(NC)"
-	@$(BREW_WITH_POLICY) bundle install --no-upgrade --file="$(BREWFILE)"
+	@$(BREW_BUNDLE_INSTALL) "$(BREWFILE)"
 
 .PHONY: audio-priority-bar-install
 audio-priority-bar-install: ## Install the pinned AudioPriorityBar release on macOS
@@ -135,7 +136,7 @@ personal-setup: ## Full personal Mac setup (bootstrap + macOS settings + SSH)
 ##@ Update
 
 .PHONY: update
-update: ## Update brew packages, mise tools, and Mac App Store apps
+update: ## Update installed brew packages, mise tools, and Mac App Store apps
 	@if [ "$(HOST_OS)" = "Darwin" ]; then \
 		$(BREW_UPDATE) update-all; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ endif
 
 BREW_WITH_POLICY := ./scripts/brew-with-policy.sh
 BREW_UPDATE := ./scripts/brew-update.sh
+AUDIO_PRIORITY_BAR_INSTALL := ./scripts/install-audio-priority-bar.sh
 
 HOST_OS := $(shell uname -s)
 BREWFILE := $(if $(filter Darwin,$(HOST_OS)),Brewfile,Brewfile.posix)
@@ -45,9 +46,9 @@ BREWFILE := $(if $(filter Darwin,$(HOST_OS)),Brewfile,Brewfile.posix)
 MACOS_PROFILE ?= personal
 
 ifeq ($(HOST_OS),Darwin)
-INSTALL_TARGETS := brewfile-install stow mise-install
+INSTALL_TARGETS := brewfile-install audio-priority-bar-install stow-install mise-install
 else
-INSTALL_TARGETS := stow mise-install
+INSTALL_TARGETS := stow-install mise-install
 endif
 
 # Default target
@@ -86,11 +87,23 @@ brewfile-install: ## Install packages from the Brewfile (Brewfile.posix on Linux
 		exit 1; \
 	fi
 	@echo "$(BLUE)Installing via brew bundle: $(BREWFILE)$(NC)"
-	@$(BREW_WITH_POLICY) bundle --file="$(BREWFILE)"
+	@$(BREW_WITH_POLICY) bundle install --no-upgrade --file="$(BREWFILE)"
+
+.PHONY: audio-priority-bar-install
+audio-priority-bar-install: ## Install the pinned AudioPriorityBar release on macOS
+	@if [ "$(HOST_OS)" != "Darwin" ]; then \
+		echo "$(RED)AudioPriorityBar is macOS-only$(NC)"; \
+		exit 1; \
+	fi
+	@$(AUDIO_PRIORITY_BAR_INSTALL)
 
 .PHONY: stow
 stow: ## Symlink dotfiles into the home directory
 	@./stow.sh
+
+.PHONY: stow-install
+stow-install: ## Symlink dotfiles, preserving unmanaged conflicts in a backup
+	@./stow.sh --backup-conflicts
 
 .PHONY: mise-install
 mise-install: ## Install CLI tools and runtimes declared in mise config
@@ -109,7 +122,7 @@ linux-install: ## Install Linux dotfiles and mise tools without Homebrew
 		echo "$(RED)linux-install is for Linux; use make install on macOS$(NC)"; \
 		exit 1; \
 	fi
-	@$(MAKE) stow mise-install
+	@$(MAKE) stow-install mise-install
 
 .PHONY: omarchy-setup
 omarchy-setup: ## Run the idempotent Arch/Omarchy setup flow

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ lint: ## Run linters (shellcheck, markdownlint)
 	@./_test/shellcheck.sh
 	@echo "$(YELLOW)Running markdownlint...$(NC)"
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-		find . -name "*.md" -not -path "./_test/*" -not -path "./.git/*" -exec markdownlint-cli2 {} + ; \
+		git ls-files -z -- "*.md" | xargs -0 markdownlint-cli2; \
 	else \
 		echo "  markdownlint-cli2 not available"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ make install    # host-appropriate package layer + stow + mise (idempotent)
 make update     # update brew, mise, and Mac App Store packages
 ```
 
+If an older unmanaged dotfile conflicts with a tracked Stow package,
+`make install` moves the old file under
+`${XDG_STATE_HOME:-~/.local/state}/n-dotfiles/stow-backups/` before linking the
+repository version. The backup path is printed during installation.
+
 ### Stow-only machine (e.g. work)
 
 The work machine gets dotfiles only — no package management:
@@ -84,6 +89,10 @@ cd n-dotfiles
 
 `./stow.sh --adopt` pulls pre-existing real files into the repo if you
 want to keep them — review with `git diff` afterwards.
+`./stow.sh --backup-conflicts` instead preserves those files in a separate
+backup and keeps the repository version authoritative. Plain `./stow.sh` and
+`make stow` remain conservative and fail before changing anything when a
+conflict exists.
 
 ### Linux
 
@@ -147,6 +156,18 @@ mise use -g foo@latest # add + install a global tool in one step
 
 Add a `cask`/`brew`/`mas` line to the [Brewfile](Brewfile) and run
 `make install` (or `brew bundle --file Brewfile`).
+
+AudioPriorityBar is the one exception: upstream currently publishes a GitHub
+release rather than a Homebrew cask. Its pinned universal release and
+SHA-256 are managed by
+[`scripts/install-audio-priority-bar.sh`](scripts/install-audio-priority-bar.sh)
+and run automatically by `make install` on macOS. Use `--dry-run` to preview
+the install.
+
+The `audio-priority-bar` Stow package links the stable priority configuration
+to `~/.config/audio-priority-bar/preferences.plist`. The installer merges
+those keys into the app's `com.example.AudioPriorityBar` UserDefaults domain
+on every run while preserving its timestamped `knownDevices` cache.
 
 To find drift in either direction, run `make audit` — it reports
 Brewfile entries missing from the machine and installed packages

--- a/README.md
+++ b/README.md
@@ -175,8 +175,12 @@ missing from the Brewfile.
 
 ## Harness Assets
 
-Private harness assets are synced from the optional sibling
+Private harness assets are reconciled from the optional sibling
 `../harnesses-private` repo into the global, Claude, and Codex skill roots.
+Only skills selected by provider load manifests are exposed. When two loaded
+providers use the same skill directory name, the sync uses a deterministic
+`<provider>-<skill>` destination name for both skills. Stale private links are
+removed during reconciliation.
 Run this from the `n-dotfiles` repo root:
 
 ```bash

--- a/_test/README.md
+++ b/_test/README.md
@@ -47,8 +47,10 @@ bats _test/makefile.bats --verbose-run
 ## Test Structure
 
 - `bootstrap.bats` - CLI contract and dry-run behavior of `bootstrap.sh`
+- `audio-priority-bar-config.bats` - stable preference merge and installer integration
 - `cli-contracts.bats` - `--help`/`--dry-run` contracts for user-facing scripts, including `stow.sh`
 - `makefile.bats` - Makefile targets (install, stow, mise-install, update, configure)
+- `stow.bats` - conflict preflight, recoverable backups, and Stow transaction behavior
 - `setup-personal-mac.bats` - Orchestration flow of `setup-personal-mac.sh`
 - `macos.bats` - macOS defaults logic (`_macos/macos.sh`)
 - `shell-configs.bats` - bash/zsh startup behavior and PATH ordering

--- a/_test/audio-priority-bar-config.bats
+++ b/_test/audio-priority-bar-config.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+setup() {
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export TEST_ROOT
+  TEST_ROOT="$(mktemp -d)"
+  export TEST_BIN="$TEST_ROOT/bin"
+  export LIVE_PLIST="$TEST_ROOT/live.plist"
+  export IMPORTED_PLIST="$TEST_ROOT/imported.plist"
+  mkdir -p "$TEST_BIN"
+
+  cat > "$TEST_BIN/defaults" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  export)
+    cp "$LIVE_PLIST" "$3"
+    ;;
+  import)
+    cp "$3" "$IMPORTED_PLIST"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$TEST_BIN/defaults"
+
+  cat > "$LIVE_PLIST" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>inputPriorities</key><array><string>old-device</string></array>
+  <key>knownDevices</key><data>Y2FjaGU=</data>
+</dict></plist>
+EOF
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "AudioPriorityBar config merges managed keys without deleting its device cache" {
+  local config="$TEST_ROOT/preferences.plist"
+  cat > "$config" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>currentMode</key><string>speaker</string>
+  <key>inputPriorities</key><array><string>vocaster</string><string>webcam</string></array>
+</dict></plist>
+EOF
+
+  run env PATH="$TEST_BIN:/usr/bin:/bin" \
+    "$REPO_ROOT/scripts/configure-audio-priority-bar.sh" --config "$config"
+
+  [ "$status" -eq 0 ]
+  [ "$(plutil -extract currentMode raw -o - "$IMPORTED_PLIST")" = "speaker" ]
+  [ "$(plutil -extract inputPriorities.0 raw -o - "$IMPORTED_PLIST")" = "vocaster" ]
+  [ "$(plutil -extract inputPriorities.1 raw -o - "$IMPORTED_PLIST")" = "webcam" ]
+  [ "$(plutil -extract knownDevices raw -o - "$IMPORTED_PLIST")" = "Y2FjaGU=" ]
+}
+
+@test "AudioPriorityBar installer reapplies preferences when the pinned app is already installed" {
+  local app_dir="$TEST_ROOT/Applications"
+  local configure_log="$TEST_ROOT/configure.log"
+  mkdir -p "$app_dir/AudioPriorityBar.app"
+  printf '%s\n' \
+    'v1.2.1 f29f23d8cfcb90765aa5716983254d8aa6ac3c725de87b3aed8614eef0873bc0' \
+    > "$app_dir/.AudioPriorityBar.release"
+  cat > "$TEST_ROOT/configure" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "configured \$*" > "$configure_log"
+EOF
+  chmod +x "$TEST_ROOT/configure"
+
+  run env \
+    AUDIO_PRIORITY_BAR_APP_DIR="$app_dir" \
+    AUDIO_PRIORITY_BAR_CONFIGURE_SCRIPT="$TEST_ROOT/configure" \
+    "$REPO_ROOT/scripts/install-audio-priority-bar.sh"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$configure_log")" = "configured " ]
+  [[ "$output" == *"already installed"* ]]
+}

--- a/_test/bootstrap-omarchy.bats
+++ b/_test/bootstrap-omarchy.bats
@@ -16,6 +16,10 @@ setup() {
   mock_command "mise" 0 ""
   mock_command "hyprctl" 0 ""
   # shellcheck disable=SC2016 # Expanded by the generated mock at runtime.
+  mock_command_with_script "uname" '[[ "${1:-}" == "-s" ]] && echo Linux'
+  # shellcheck disable=SC2016 # Expanded by the generated mock at runtime.
+  mock_command_with_script "locale" '[[ "${1:-}" == "-a" ]] && echo en_GB.utf8'
+  # shellcheck disable=SC2016 # Expanded by the generated mock at runtime.
   mock_command_with_script "getent" 'echo "${2:-nick}:x:1000:1000::/home/test:/usr/bin/bash"'
   mock_stow
 }
@@ -94,6 +98,8 @@ teardown() {
 }
 
 @test "bootstrap-omarchy: sets zsh as the login shell through the public flow" {
+  local zsh_path
+  zsh_path="$(readlink -f "$(command -v zsh)")"
   ln -s "$REPO_ROOT/zsh/.zshrc" "$TEST_HOME/.zshrc"
 
   run env \
@@ -104,12 +110,14 @@ teardown() {
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"Setting Zsh as the login shell"* ]]
-  assert_mock_called sudo "chsh -s /usr/bin/zsh"
+  assert_mock_called sudo "chsh -s $zsh_path"
 }
 
 @test "bootstrap-omarchy: leaves an existing zsh login shell unchanged" {
+  local zsh_path
+  zsh_path="$(readlink -f "$(command -v zsh)")"
   # shellcheck disable=SC2016 # Expanded by the generated mock at runtime.
-  mock_command_with_script "getent" 'echo "${2:-nick}:x:1000:1000::/home/test:/usr/bin/zsh"'
+  mock_command_with_script "getent" "echo \"\${2:-nick}:x:1000:1000::/home/test:$zsh_path\""
   ln -s "$REPO_ROOT/zsh/.zshrc" "$TEST_HOME/.zshrc"
 
   run env \

--- a/_test/check-1password-dev-tools.bats
+++ b/_test/check-1password-dev-tools.bats
@@ -75,11 +75,15 @@ esac
   mock_op_signed_in
   git config --file "$gitconfig" gpg.ssh.program "$FAKE_SIGNER"
   mkdir -p "$TEST_TMP_DIR/.1password"
-  python3 -c "
+  if [[ -n "${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
+    ln -s "$SSH_AUTH_SOCK" "$TEST_TMP_DIR/.1password/agent.sock"
+  else
+    python3 -c "
 import socket, sys
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 s.bind(sys.argv[1])
 " "$TEST_TMP_DIR/.1password/agent.sock"
+  fi
 
   run env HOME="$TEST_TMP_DIR" SSH_AUTH_SOCK="" PATH="$MOCK_BIN_DIR:/usr/bin:/bin" \
     "$CHECK_SCRIPT" --signer-path "$FAKE_SIGNER" --wrapper-path "$FAKE_SIGNER" \

--- a/_test/check-1password-dev-tools.bats
+++ b/_test/check-1password-dev-tools.bats
@@ -71,24 +71,36 @@ esac
 }
 
 @test "check-1password-dev-tools: finds the SSH agent socket at a candidate path" {
-  mkdir -p "$TEST_TMP_DIR/dot1password"
+  local gitconfig="$TEST_TMP_DIR/gitconfig"
+  mock_op_signed_in
+  git config --file "$gitconfig" gpg.ssh.program "$FAKE_SIGNER"
+  mkdir -p "$TEST_TMP_DIR/.1password"
   python3 -c "
 import socket, sys
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 s.bind(sys.argv[1])
-" "$TEST_TMP_DIR/dot1password/agent.sock"
+" "$TEST_TMP_DIR/.1password/agent.sock"
 
-  run env HOME="$TEST_TMP_DIR" PATH="$MOCK_BIN_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" --signer-path "$FAKE_SIGNER"
+  run env HOME="$TEST_TMP_DIR" SSH_AUTH_SOCK="" PATH="$MOCK_BIN_DIR:/usr/bin:/bin" \
+    "$CHECK_SCRIPT" --signer-path "$FAKE_SIGNER" --wrapper-path "$FAKE_SIGNER" \
+    --gitconfig "$gitconfig"
 
-  [[ "$output" == *"OK   1Password SSH agent socket found: $TEST_TMP_DIR/dot1password/agent.sock"* ]] || [[ "$output" == *"agent.sock"* ]]
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK   1Password SSH agent socket found: $TEST_TMP_DIR/.1password/agent.sock"* ]]
 }
 
 @test "check-1password-dev-tools: reports missing SSH agent socket" {
   local empty_home
+  local gitconfig="$TEST_TMP_DIR/gitconfig"
   empty_home="$(mktemp -d)"
+  mock_op_signed_in
+  git config --file "$gitconfig" gpg.ssh.program "$FAKE_SIGNER"
 
-  run env HOME="$empty_home" XDG_RUNTIME_DIR="$empty_home/run" PATH="$MOCK_BIN_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" --signer-path "$FAKE_SIGNER"
+  run env HOME="$empty_home" XDG_RUNTIME_DIR="$empty_home/run" SSH_AUTH_SOCK="" \
+    PATH="$MOCK_BIN_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" \
+    --signer-path "$FAKE_SIGNER" --wrapper-path "$FAKE_SIGNER" --gitconfig "$gitconfig"
 
+  [ "$status" -gt 0 ]
   [[ "$output" == *"FAIL 1Password SSH agent socket not found"* ]]
 
   rm -rf "$empty_home"

--- a/_test/cli-contracts.bats
+++ b/_test/cli-contracts.bats
@@ -44,6 +44,8 @@ EOF
     "scripts/audit-installed.sh"
     "scripts/sync-private-harness-assets.sh"
     "scripts/build-browser-tools.sh"
+    "scripts/install-audio-priority-bar.sh"
+    "scripts/configure-audio-priority-bar.sh"
     "scripts/check-1password-dev-tools.sh"
     "slicer-mac/check-slicer-version.sh"
     "slicer-mac/install-slicer-mac.sh"
@@ -116,6 +118,10 @@ EOF
   [[ "$output" == *"git"* ]]
   [[ "$output" == *"mise"* ]]
   [[ "$output" != *"vscode"* ]]
+  [[ "$output" != *"factory"* ]]
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    [[ "$output" == *"audio-priority-bar"* ]]
+  fi
 }
 
 @test "stow: rejects unknown packages" {

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -61,12 +61,20 @@ EOF
   touch _macos/personal.yaml _macos/work.yaml
 
   mkdir -p scripts
-  for script in brew-with-policy.sh brew-update.sh; do
+  for script in brew-with-policy.sh brew-update.sh install-audio-priority-bar.sh; do
     if [ -f "$REPO_ROOT/scripts/$script" ]; then
       cp "$REPO_ROOT/scripts/$script" scripts/
       chmod +x "scripts/$script"
     fi
   done
+
+  # Keep the Makefile test hermetic on macOS: the real installer downloads a
+  # pinned release, while this suite only needs to verify target wiring.
+  cat > scripts/install-audio-priority-bar.sh <<'EOF'
+#!/usr/bin/env bash
+echo "audio-priority-bar installer called"
+EOF
+  chmod +x scripts/install-audio-priority-bar.sh
 
   # Copy the Makefile
   cp "$REPO_ROOT/Makefile" .
@@ -109,7 +117,7 @@ teardown() {
   else
     [[ "$output" != *"brew bundle called"* ]]
   fi
-  [[ "$output" == *"stow.sh called with:"* ]]
+  [[ "$output" == *"stow.sh called with: --backup-conflicts"* ]]
   [[ "$output" == *"mise install"* ]]
 }
 
@@ -132,6 +140,7 @@ teardown() {
   run make stow
   [ "$status" -eq 0 ]
   [[ "$output" == *"stow.sh called with:"* ]]
+  [[ "$output" != *"--backup-conflicts"* ]]
 }
 
 @test "make mise-install runs mise install" {

--- a/_test/makefile.bats
+++ b/_test/makefile.bats
@@ -27,9 +27,25 @@ setup() {
 #!/usr/bin/env bash
 if [[ "$1" == "bundle" ]]; then
   shift
+  if [[ "$1" == "list" && "$2" == "--cask" ]]; then
+    printf '%s\n' brave-browser alfred ghostty
+    exit 0
+  fi
+  if [[ "$1" == "list" && "$2" == "--formula" ]]; then
+    printf '%s\n' fzf mise tmux azure/functions/azure-functions-core-tools@4
+    exit 0
+  fi
   printf "%s\n" "$@" > "${TEST_DIR}/brew-bundle-args.txt"
-  printf "%s\t%s\n" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" > "${TEST_DIR}/brew-policy-env.txt"
+  printf "%s\t%s\t%s\t%s\n" "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" "${HOMEBREW_NO_ENV_HINTS:-}" "${HOMEBREW_BUNDLE_CASK_SKIP:-}" "${HOMEBREW_BUNDLE_BREW_SKIP:-}" > "${TEST_DIR}/brew-policy-env.txt"
   echo "brew bundle called"
+  exit 0
+fi
+if [[ "$1" == "list" && "$2" == "--cask" ]]; then
+  printf '%s\n' brave-browser alfred
+  exit 0
+fi
+if [[ "$1" == "list" && "$2" == "--formula" ]]; then
+  printf '%s\n' fzf mise azure-functions-core-tools@4
   exit 0
 fi
 echo "brew $*"
@@ -61,7 +77,7 @@ EOF
   touch _macos/personal.yaml _macos/work.yaml
 
   mkdir -p scripts
-  for script in brew-with-policy.sh brew-update.sh install-audio-priority-bar.sh; do
+  for script in brew-bundle-install.sh brew-with-policy.sh brew-update.sh install-audio-priority-bar.sh; do
     if [ -f "$REPO_ROOT/scripts/$script" ]; then
       cp "$REPO_ROOT/scripts/$script" scripts/
       chmod +x "scripts/$script"
@@ -134,6 +150,29 @@ teardown() {
   [ "$status" -eq 0 ]
   run awk -F '\t' '$1 == "1" && $2 == "1" { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
   [ "$status" -eq 0 ]
+}
+
+@test "make brewfile-install installs only missing formulae and casks" {
+  run make brewfile-install
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Using brave-browser (installed)"* ]]
+  [[ "$output" == *"Using alfred"* ]]
+  [[ "$output" == *"Using fzf (installed)"* ]]
+  [[ "$output" == *"Using azure/functions/azure-functions-core-tools@4 (installed)"* ]]
+  run awk -F '\t' '$3 ~ /(^| )brave-browser( |$)/ && $3 ~ /(^| )alfred( |$)/ { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$4 ~ /(^| )fzf( |$)/ && $4 ~ /(^| )mise( |$)/ { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+  run awk -F '\t' '$4 ~ /(^| )azure\/functions\/azure-functions-core-tools@4( |$)/ { found = 1 } END { exit found ? 0 : 1 }' "$TEST_DIR/brew-policy-env.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "Homebrew update upgrades installed formulae and casks explicitly" {
+  run scripts/brew-update.sh update-all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"brew upgrade --formula"* ]]
+  [[ "$output" == *"brew upgrade --cask"* ]]
+  [[ "$output" != *"Pearcleaner"* ]]
 }
 
 @test "make stow calls stow.sh" {

--- a/_test/shell-configs.bats
+++ b/_test/shell-configs.bats
@@ -410,6 +410,42 @@ EOF
   [ "$zsh_shims_index" -lt "$zsh_brew_index" ]
 }
 
+@test "both configs: prefer mise and keep Arkade as the final PATH fallback" {
+  mkdir -p "$HOME/.local/share/mise/shims" "$HOME/.arkade/bin"
+  printf '%s\n' '#!/usr/bin/env bash' > "$HOME/.local/share/mise/shims/gh"
+  printf '%s\n' '#!/usr/bin/env bash' > "$HOME/.arkade/bin/gh"
+  chmod +x "$HOME/.local/share/mise/shims/gh" "$HOME/.arkade/bin/gh"
+  local inherited_path="$HOME/.arkade/bin:/opt/homebrew/bin:/usr/bin:/bin"
+
+  result=$(bash -c "
+    export PATH='$inherited_path'
+    source $DOTFILES_DIR/bash/.bashrc 2>/dev/null
+    printf '%s\n%s\n' \$PATH \$(command -v gh)
+  ")
+  local bash_path="${result%%$'\n'*}"
+  local bash_gh="${result#*$'\n'}"
+  [ "${bash_path##*:}" = "$HOME/.arkade/bin" ]
+  [ "$bash_gh" = "$HOME/.local/share/mise/shims/gh" ]
+
+  result=$(zsh -c "
+    export PATH='$inherited_path'
+    source $DOTFILES_DIR/zsh/.zshrc 2>/dev/null
+    printf '%s\n%s\n' \$PATH \$(command -v gh)
+  ")
+  local zsh_path="${result%%$'\n'*}"
+  local zsh_gh="${result#*$'\n'}"
+  [ "${zsh_path##*:}" = "$HOME/.arkade/bin" ]
+  [ "$zsh_gh" = "$HOME/.local/share/mise/shims/gh" ]
+}
+
+@test "gitconfig: GitHub credential helper resolves gh portably from PATH" {
+  run git config --file "$DOTFILES_DIR/git/.gitconfig" --get-all credential.https://github.com.helper
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'!gh auth git-credential'* ]]
+  [[ "$output" != *'/Users/'* ]]
+}
+
 @test "zshrc: does not cache mise activate output to a file" {
   # mise activate's output bakes in a literal `export PATH='...'` snapshot
   # of the PATH at generation time, so caching it (like starship/direnv/etc)

--- a/_test/stow.bats
+++ b/_test/stow.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_ROOT
+  TEST_ROOT="$(mktemp -d)"
+  export TEST_HOME="$TEST_ROOT/home"
+  export TEST_REPO="$TEST_ROOT/repo"
+  mkdir -p "$TEST_HOME" "$TEST_REPO/zsh"
+  cp "$BATS_TEST_DIRNAME/../stow.sh" "$TEST_REPO/stow.sh"
+  chmod +x "$TEST_REPO/stow.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "stow backup mode preserves an unmanaged dotfile before replacing it" {
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  printf '%s\n' 'previous local zsh config' > "$TEST_HOME/.zshrc"
+  local backup_dir="$TEST_ROOT/backups"
+
+  run env HOME="$TEST_HOME" \
+    /bin/bash "$TEST_REPO/stow.sh" --backup-conflicts --backup-dir "$backup_dir" zsh
+
+  [ "$status" -eq 0 ]
+  [ -L "$TEST_HOME/.zshrc" ]
+  [ "$(cat "$TEST_HOME/.zshrc")" = "repository zsh config" ]
+  [ "$(cat "$backup_dir/.zshrc")" = "previous local zsh config" ]
+  [[ "$output" == *"Backed up .zshrc"* ]]
+}
+
+@test "stow backup mode uses the XDG state directory by default" {
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  printf '%s\n' 'previous local zsh config' > "$TEST_HOME/.zshrc"
+  local state_dir="$TEST_ROOT/state"
+
+  run env HOME="$TEST_HOME" XDG_STATE_HOME="$state_dir" \
+    "$TEST_REPO/stow.sh" --backup-conflicts zsh
+
+  [ "$status" -eq 0 ]
+  run find "$state_dir/n-dotfiles/stow-backups" -type f -name .zshrc -exec cat {} \;
+  [ "$status" -eq 0 ]
+  [ "$output" = "previous local zsh config" ]
+}
+
+@test "stow rejects dry-run recovery without moving a conflict" {
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  printf '%s\n' 'unmanaged zsh config' > "$TEST_HOME/.zshrc"
+
+  run env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" --dry-run --backup-conflicts zsh
+
+  [ "$status" -eq 1 ]
+  [ "$(cat "$TEST_HOME/.zshrc")" = "unmanaged zsh config" ]
+  [[ "$output" == *"--dry-run and --backup-conflicts cannot be used together"* ]]
+}
+
+@test "stow detects all conflicts before changing any package" {
+  mkdir -p "$TEST_REPO/aerospace/.config/aerospace"
+  printf '%s\n' 'aerospace config' > "$TEST_REPO/aerospace/.config/aerospace/aerospace.toml"
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  printf '%s\n' 'unmanaged zsh config' > "$TEST_HOME/.zshrc"
+
+  run env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" aerospace zsh
+
+  [ "$status" -eq 1 ]
+  [ ! -e "$TEST_HOME/.config" ]
+  [ ! -L "$TEST_HOME/.config" ]
+  [ "$(cat "$TEST_HOME/.zshrc")" = "unmanaged zsh config" ]
+}
+
+@test "stow restores staged backups when recovery preflight fails" {
+  mkdir -p "$TEST_REPO/mise/.config/mise"
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  printf '%s\n' 'repository mise config' > "$TEST_REPO/mise/.config/mise/config.toml"
+  printf '%s\n' 'unmanaged zsh config' > "$TEST_HOME/.zshrc"
+  printf '%s\n' 'blocks the .config directory' > "$TEST_HOME/.config"
+  local backup_dir="$TEST_ROOT/backups"
+
+  run env HOME="$TEST_HOME" \
+    "$TEST_REPO/stow.sh" --backup-conflicts --backup-dir "$backup_dir" zsh mise
+
+  [ "$status" -eq 1 ]
+  [ ! -L "$TEST_HOME/.zshrc" ]
+  [ "$(cat "$TEST_HOME/.zshrc")" = "unmanaged zsh config" ]
+  [ ! -e "$backup_dir/.zshrc" ]
+}

--- a/_test/stow.bats
+++ b/_test/stow.bats
@@ -14,6 +14,30 @@ teardown() {
   rm -rf "$TEST_ROOT"
 }
 
+@test "stow is idempotent without unlinking correct links" {
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+
+  run env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" zsh
+  [ "$status" -eq 0 ]
+  [ -L "$TEST_HOME/.zshrc" ]
+
+  run env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" zsh
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"UNLINK:"* ]]
+  [[ "$output" != *"LINK:"* ]]
+}
+
+@test "stow restow mode remains explicit" {
+  printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
+  env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" zsh >/dev/null
+
+  run env HOME="$TEST_HOME" "$TEST_REPO/stow.sh" --restow zsh
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"UNLINK: .zshrc"* ]]
+  [[ "$output" == *"LINK: .zshrc"* ]]
+}
+
 @test "stow list exposes macOS packages only on Darwin" {
   local mock_bin="$TEST_ROOT/bin"
   mkdir -p "$mock_bin"
@@ -69,6 +93,23 @@ teardown() {
   run find "$state_dir/n-dotfiles/stow-backups" -type f -name .zshrc -exec cat {} \;
   [ "$status" -eq 0 ]
   [ "$output" = "previous local zsh config" ]
+}
+
+@test "stow backup mode leaves package-local ignored files untouched" {
+  mkdir -p "$TEST_REPO/codex/.codex/rules" "$TEST_HOME/.codex"
+  printf '%s\n' 'config\.toml' > "$TEST_REPO/codex/.stow-local-ignore"
+  printf '%s\n' 'repository placeholder' > "$TEST_REPO/codex/.codex/config.toml"
+  printf '%s\n' 'repository rule' > "$TEST_REPO/codex/.codex/rules/default.rules"
+  printf '%s\n' 'live machine config' > "$TEST_HOME/.codex/config.toml"
+  local backup_dir="$TEST_ROOT/backups"
+
+  run env HOME="$TEST_HOME" \
+    "$TEST_REPO/stow.sh" --backup-conflicts --backup-dir "$backup_dir" codex
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_HOME/.codex/config.toml")" = "live machine config" ]
+  [ ! -e "$backup_dir/.codex/config.toml" ]
+  [ -L "$TEST_HOME/.codex/rules" ]
 }
 
 @test "stow rejects dry-run recovery without moving a conflict" {

--- a/_test/stow.bats
+++ b/_test/stow.bats
@@ -14,6 +14,34 @@ teardown() {
   rm -rf "$TEST_ROOT"
 }
 
+@test "stow list exposes macOS packages only on Darwin" {
+  local mock_bin="$TEST_ROOT/bin"
+  mkdir -p "$mock_bin"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo Darwin' >"$mock_bin/uname"
+  chmod +x "$mock_bin/uname"
+
+  run env PATH="$mock_bin:$PATH" "$TEST_REPO/stow.sh" --list
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aerospace"* ]]
+  [[ "$output" == *"audio-priority-bar"* ]]
+  [[ "$output" != *"omarchy"* ]]
+}
+
+@test "stow list excludes macOS packages on Linux" {
+  local mock_bin="$TEST_ROOT/bin"
+  mkdir -p "$mock_bin"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo Linux' >"$mock_bin/uname"
+  chmod +x "$mock_bin/uname"
+
+  run env PATH="$mock_bin:$PATH" "$TEST_REPO/stow.sh" --list
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"aerospace"* ]]
+  [[ "$output" != *"audio-priority-bar"* ]]
+  [[ "$output" == *"omarchy"* ]]
+}
+
 @test "stow backup mode preserves an unmanaged dotfile before replacing it" {
   printf '%s\n' 'repository zsh config' > "$TEST_REPO/zsh/.zshrc"
   printf '%s\n' 'previous local zsh config' > "$TEST_HOME/.zshrc"

--- a/audio-priority-bar/.config/audio-priority-bar/preferences.plist
+++ b/audio-priority-bar/.config/audio-priority-bar/preferences.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>currentMode</key>
+	<string>speaker</string>
+	<key>customMode</key>
+	<false/>
+	<key>hiddenMics</key>
+	<array>
+		<string>MSLoopbackDriverDevice_UID</string>
+	</array>
+	<key>hiddenSpeakers</key>
+	<array>
+		<string>AppleUSBAudioEngine:Samson Technologies:Samson Q2U Microphone:2120000:2,1</string>
+	</array>
+	<key>inputPriorities</key>
+	<array>
+		<string>AppleUSBAudioEngine:Samson Technologies:Samson Q2U Microphone:2120000:2,1</string>
+		<string>AppleUSBAudioEngine:Unknown Manufacturer:HD Pro Webcam C920:0FEA3EAF:3</string>
+		<string>AppleUSBAudioEngine:Focusrite:Vocaster Two USB:V2UPRVX2500E08:1,2</string>
+	</array>
+	<key>speakerPriorities</key>
+	<array>
+		<string>AppleUSBAudioEngine:Focusrite:Vocaster Two USB:V2UPRVX2500E08:1,2</string>
+		<string>26CD3066-0000-0000-011F-0103803C2278</string>
+		<string>BuiltInSpeakerDevice</string>
+		<string>MSLoopbackDriverDevice_UID</string>
+	</array>
+</dict>
+</plist>

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -60,8 +60,10 @@ for path_entry in "${paths[@]}"; do
   fi
 done
 
-# De-duplicate PATH and remove empty entries
-PATH=$(echo "$PATH" | awk -v RS=: '!a[$0]++' | grep -v '^$' | paste -sd: -)
+# De-duplicate PATH and keep Arkade as a fallback behind mise and system tools.
+ARKADE_BIN="$HOME/.arkade/bin"
+PATH=$(echo "$PATH" | awk -v RS=: -v arkade="$ARKADE_BIN" '$0 != arkade && !a[$0]++' | grep -v '^$' | paste -sd: -)
+[[ -d "$ARKADE_BIN" ]] && PATH="$PATH:$ARKADE_BIN"
 export PATH
 
 #

--- a/bootstrap-omarchy.sh
+++ b/bootstrap-omarchy.sh
@@ -145,7 +145,7 @@ load_and_validate_stow_packages() {
   fi
 
   local available pkg
-  available="$($BOOTSTRAP_DIR/stow.sh --list)"
+  available="$("$BOOTSTRAP_DIR/stow.sh" --list)"
   for pkg in "${STOW_PACKAGE_ARGS[@]}"; do
     if ! grep -qxF "$pkg" <<<"$available"; then
       error "Unknown stow package: $pkg (use './stow.sh --list' to see packages)"
@@ -190,7 +190,13 @@ run_stow_if_needed() {
   # must not block unrelated later steps like keyd/hypr/mise — stow.sh
   # itself already continues past a failed package to the rest of the
   # list, so mirror that here rather than aborting the whole bootstrap.
-  if ! "$BOOTSTRAP_DIR/stow.sh" "${stow_args[@]}" "${STOW_PACKAGE_ARGS[@]}"; then
+  local stow_status=0
+  if [[ ${#stow_args[@]} -gt 0 ]]; then
+    "$BOOTSTRAP_DIR/stow.sh" "${stow_args[@]}" "${STOW_PACKAGE_ARGS[@]}" || stow_status=$?
+  else
+    "$BOOTSTRAP_DIR/stow.sh" "${STOW_PACKAGE_ARGS[@]}" || stow_status=$?
+  fi
+  if [[ "$stow_status" -ne 0 ]]; then
     error "Stow reported conflicts on one or more packages. Existing real files are in the way."
     error "Review them, then re-run './stow.sh' (or './stow.sh --adopt' to pull them into the repo — check 'git diff' afterwards)."
     error "Continuing with the rest of bootstrap; packages that failed to stow are simply not linked yet."
@@ -207,32 +213,22 @@ check_stowed_binaries() {
   echo
   info "Checking that stowed packages have their tool installed..."
 
-  # Packages with no corresponding binary (meta/skill packages, or where the
-  # binary name doesn't match the package name in an obvious way) are
-  # intentionally absent from this table and skipped.
-  local -A package_binary=(
-    [aerospace]=aerospace
-    [aws]=aws
-    [bash]=bash
-    [bat]=bat
-    [gh]=gh
-    [ghostty]=ghostty
-    [git]=git
-    [kitty]=kitty
-    [mise]=mise
-    [nushell]=nu
-    [nvim]=nvim
-    [prettier]=prettier
-    [starship]=starship
-    [tmux]=tmux
-    [yazi]=yazi
-    [zsh]=zsh
-  )
-
   local pkg binary any_missing=false
   for pkg in "${STOW_PACKAGE_ARGS[@]}"; do
-    binary="${package_binary[$pkg]:-}"
-    [[ -z "$binary" ]] && continue
+    # Packages with no corresponding binary (meta/skill packages, or where
+    # the binary name is not obvious) are intentionally skipped. A case keeps
+    # this entrypoint compatible with macOS's stock Bash 3 as well as Arch.
+    case "$pkg" in
+      aerospace | aws | bash | bat | gh | ghostty | git | kitty | mise | nvim | prettier | starship | tmux | yazi | zsh)
+        binary=$pkg
+        ;;
+      nushell)
+        binary=nu
+        ;;
+      *)
+        continue
+        ;;
+    esac
     if ! command_exists "$binary"; then
       info "  WARN $pkg: config stowed, but '$binary' is not on PATH"
       any_missing=true
@@ -258,14 +254,9 @@ stow_package_requested() {
 check_zsh_plugins() {
   stow_package_requested zsh || return 0
 
-  local -A plugin_path=(
-    [zsh-autosuggestions]="$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
-    [zsh-syntax-highlighting]="$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-  )
-
   local plugin plugin_file any_missing=false
-  for plugin in "${!plugin_path[@]}"; do
-    plugin_file="${plugin_path[$plugin]}"
+  for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
+    plugin_file="$ZSH_PLUGIN_DIR/$plugin/$plugin.zsh"
     if [[ ! -f "$plugin_file" ]]; then
       info "  WARN $plugin: zsh is stowed, but $plugin_file is missing (pacman -S $plugin)"
       any_missing=true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,3 +110,23 @@ npm dependency footprint where package metadata is local.
 ./scripts/audit-installed.sh --out-base /tmp/n-dotfiles-audit
 make audit-installed
 ```
+
+## install-audio-priority-bar
+
+Install the pinned universal macOS release of Tobi's AudioPriorityBar into
+`~/Applications`. The script verifies the release archive's SHA-256 and is
+idempotent; `make install` runs it automatically on macOS.
+
+```bash
+./scripts/install-audio-priority-bar.sh --dry-run
+./scripts/install-audio-priority-bar.sh
+```
+
+The installer also runs `configure-audio-priority-bar.sh`, which merges the
+stable preferences from the `audio-priority-bar` Stow package into the app's
+UserDefaults domain without replacing its volatile device cache.
+
+```bash
+./scripts/configure-audio-priority-bar.sh --dry-run
+./scripts/configure-audio-priority-bar.sh
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,14 +43,15 @@ states.
 
 ## sync-private-harness-assets
 
-Link selected private harness assets from the optional sibling
+Reconcile selected private harness assets from the optional sibling
 `../harnesses-private` repo into the global, Claude, and Codex harness views.
-The script links individual skill directories only, skips cleanly when the
-private repo is absent, and discovers provider-grouped catalogs such as
+The script links individual skill directories, skips cleanly when the private
+repo is absent, removes stale private links, and discovers provider-grouped catalogs such as
 `mattpocock/skills/tdd`, `joshpigford/skills/example`, and
 `agents/skills/use-platform`. If a provider has `load/*.txt` manifests, only
 listed skills are exposed. Supported manifests are `load/global.txt`,
-`load/claude.txt`, and `load/codex.txt`.
+`load/claude.txt`, and `load/codex.txt`. Duplicate loaded skill names are
+namespaced as `<provider>-<skill>` in the flat harness roots.
 
 Run from the `n-dotfiles` repo root. The default private source is
 `../harnesses-private`; pass `--private-root <path>` for another location.

--- a/scripts/brew-bundle-install.sh
+++ b/scripts/brew-bundle-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/brew-bundle-install.sh <Brewfile>
+
+Installs missing Brewfile entries without upgrading formulae or casks that
+Homebrew already manages. Use `make update` to update installed entries.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+brewfile=$1
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+brew_with_policy="$script_dir/brew-with-policy.sh"
+
+declared_casks=$("$brew_with_policy" bundle list --cask --file="$brewfile")
+installed_casks=$("$brew_with_policy" list --cask)
+cask_skip="${HOMEBREW_BUNDLE_CASK_SKIP:-}"
+declared_formulae=$("$brew_with_policy" bundle list --formula --file="$brewfile")
+installed_formulae=$("$brew_with_policy" list --formula)
+formula_skip="${HOMEBREW_BUNDLE_BREW_SKIP:-}"
+
+for cask in $declared_casks; do
+  case $'\n'"$installed_casks"$'\n' in
+    *$'\n'"$cask"$'\n'*)
+      printf 'Using %s (installed)\n' "$cask"
+      cask_skip="${cask_skip:+$cask_skip }$cask"
+      ;;
+  esac
+done
+
+for formula in $declared_formulae; do
+  formula_name=${formula##*/}
+  case $'\n'"$installed_formulae"$'\n' in
+    *$'\n'"$formula_name"$'\n'*)
+      printf 'Using %s (installed)\n' "$formula"
+      formula_skip="${formula_skip:+$formula_skip }$formula"
+      ;;
+  esac
+done
+
+export HOMEBREW_BUNDLE_CASK_SKIP="$cask_skip"
+export HOMEBREW_BUNDLE_BREW_SKIP="$formula_skip"
+exec "$brew_with_policy" bundle install --no-upgrade --file="$brewfile"

--- a/scripts/brew-update.sh
+++ b/scripts/brew-update.sh
@@ -34,15 +34,13 @@ context="${1:-}"
 case "$context" in
   package-manager)
     require_brew=true
-    heading="Updating Homebrew packages and casks..."
-    cask_warning="  Warning: brew upgrade --cask failed"
+    heading="Updating installed Homebrew formulae and casks..."
     success="\342\234\223 Homebrew updated"
     trailing_blank=false
     ;;
   update-all)
     require_brew=false
-    heading="Updating Homebrew..."
-    cask_warning="  Warning: brew cask upgrade failed (some casks may have issues)"
+    heading="Updating installed Homebrew formulae and casks..."
     success="\342\234\223 Homebrew update completed"
     trailing_blank=true
     ;;
@@ -66,8 +64,8 @@ fi
 
 print_color "${blue}${heading}${nc}"
 "$brew_with_policy" update || print_color "${yellow}  Warning: brew update failed${nc}"
-"$brew_with_policy" upgrade || print_color "${yellow}  Warning: brew upgrade failed${nc}"
-"$brew_with_policy" upgrade --cask || print_color "${yellow}${cask_warning}${nc}"
+"$brew_with_policy" upgrade --formula || print_color "${yellow}  Warning: brew formula upgrade failed${nc}"
+"$brew_with_policy" upgrade --cask || print_color "${yellow}  Warning: brew cask upgrade failed${nc}"
 "$brew_with_policy" cleanup || print_color "${yellow}  Warning: brew cleanup failed${nc}"
 print_color "${green}${success}${nc}"
 

--- a/scripts/configure-audio-priority-bar.sh
+++ b/scripts/configure-audio-priority-bar.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Merge the repo-managed AudioPriorityBar preferences into macOS UserDefaults.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOMAIN="com.example.AudioPriorityBar"
+STOWED_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/audio-priority-bar/preferences.plist"
+REPO_CONFIG="${SCRIPT_DIR}/../audio-priority-bar/.config/audio-priority-bar/preferences.plist"
+CONFIG_PATH=""
+CONFIG_TEMP_DIR=""
+DRY_RUN=false
+
+MANAGED_KEYS=(
+  currentMode
+  customMode
+  inputPriorities
+  speakerPriorities
+  headphonePriorities
+  deviceCategories
+  hiddenMics
+  hiddenSpeakers
+  hiddenHeadphones
+  neverUseDevices
+)
+
+usage() {
+  local exit_code=${1:-0}
+
+  cat <<EOF
+Usage: $0 [options]
+
+Merge stable AudioPriorityBar preferences into ${DOMAIN} while preserving its
+volatile knownDevices cache.
+
+Options:
+  -c, --config <path>  Read this plist instead of the stowed/repo default
+  -d, --dry-run        Validate and print the merge plan without changing defaults
+  -h, --help           Show this help message
+
+Examples:
+  $0
+  $0 --dry-run
+  $0 --config ~/.config/audio-priority-bar/preferences.plist
+EOF
+
+  exit "$exit_code"
+}
+
+error() {
+  echo "Error: $*" >&2
+}
+
+resolve_config() {
+  if [[ -n "$CONFIG_PATH" ]]; then
+    return
+  fi
+  if [[ -f "$STOWED_CONFIG" ]]; then
+    CONFIG_PATH=$STOWED_CONFIG
+  else
+    CONFIG_PATH=$REPO_CONFIG
+  fi
+}
+
+main() {
+  local working_plist key value value_type value_format managed_count=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -c | --config)
+        if [[ -n "${2:-}" && ! "$2" =~ ^- ]]; then
+          CONFIG_PATH=$2
+          shift 2
+        else
+          error "--config requires a path"
+          usage 1
+        fi
+        ;;
+      -d | --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      -h | --help)
+        usage 0
+        ;;
+      *)
+        error "Unknown option: $1"
+        usage 1
+        ;;
+    esac
+  done
+
+  resolve_config
+  if [[ ! -f "$CONFIG_PATH" ]]; then
+    error "AudioPriorityBar preferences not found: $CONFIG_PATH"
+    return 1
+  fi
+  plutil -lint "$CONFIG_PATH" >/dev/null
+
+  for key in "${MANAGED_KEYS[@]}"; do
+    if plutil -type "$key" "$CONFIG_PATH" >/dev/null 2>&1; then
+      managed_count=$((managed_count + 1))
+    fi
+  done
+  if [[ "$managed_count" -eq 0 ]]; then
+    error "No managed AudioPriorityBar keys found in $CONFIG_PATH"
+    return 1
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] Would merge ${managed_count} managed preferences from ${CONFIG_PATH} into ${DOMAIN}"
+    echo "[dry-run] Would preserve the app-managed knownDevices cache"
+    return 0
+  fi
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    error "AudioPriorityBar preferences can only be applied on macOS"
+    return 1
+  fi
+
+  CONFIG_TEMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$CONFIG_TEMP_DIR"' EXIT
+  working_plist="$CONFIG_TEMP_DIR/preferences.plist"
+  if ! defaults export "$DOMAIN" "$working_plist" >/dev/null 2>&1; then
+    plutil -create xml1 "$working_plist"
+  fi
+
+  for key in "${MANAGED_KEYS[@]}"; do
+    if ! value_type=$(plutil -type "$key" "$CONFIG_PATH" 2>/dev/null); then
+      continue
+    fi
+    case "$value_type" in
+      array | dictionary)
+        value=$(plutil -extract "$key" json -o - "$CONFIG_PATH")
+        value_format=json
+        ;;
+      *)
+        value=$(plutil -extract "$key" raw -o - "$CONFIG_PATH")
+        value_format=$value_type
+        ;;
+    esac
+    if plutil -type "$key" "$working_plist" >/dev/null 2>&1; then
+      plutil -replace "$key" "-$value_format" "$value" "$working_plist"
+    else
+      plutil -insert "$key" "-$value_format" "$value" "$working_plist"
+    fi
+  done
+
+  defaults import "$DOMAIN" "$working_plist" >/dev/null
+  echo "Applied ${managed_count} AudioPriorityBar preferences from ${CONFIG_PATH}"
+}
+
+main "$@"

--- a/scripts/install-audio-priority-bar.sh
+++ b/scripts/install-audio-priority-bar.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Install the pinned universal release of Tobi's AudioPriorityBar.
+#
+# AudioPriorityBar is not currently distributed as a Homebrew cask, so this
+# is the one macOS application installed outside Brewfile. The release URL
+# and SHA-256 are intentionally pinned; update both when adopting a release.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE="v1.2.1"
+ARCHIVE="AudioPriorityBar.zip"
+ARCHIVE_SHA256="f29f23d8cfcb90765aa5716983254d8aa6ac3c725de87b3aed8614eef0873bc0"
+RELEASE_URL="https://github.com/tobi/AudioPriorityBar/releases/download/${RELEASE}/${ARCHIVE}"
+APP_NAME="AudioPriorityBar.app"
+APP_DIR="${AUDIO_PRIORITY_BAR_APP_DIR:-${HOME}/Applications}"
+CONFIGURE_SCRIPT="${AUDIO_PRIORITY_BAR_CONFIGURE_SCRIPT:-${SCRIPT_DIR}/configure-audio-priority-bar.sh}"
+DRY_RUN=false
+INSTALL_TEMP_DIR=""
+
+usage() {
+  local exit_code=${1:-0}
+
+  cat <<EOF
+Usage: $0 [options]
+
+Install Tobi's AudioPriorityBar ${RELEASE} release into a per-user
+Applications directory. The universal binary requires macOS 13 or later.
+
+Options:
+  -a, --app-dir <path>  Install into this directory (default: ~/Applications)
+  -d, --dry-run         Print the download and install plan without changing files
+  -h, --help            Show this help message
+
+Examples:
+  $0
+  $0 --dry-run
+  $0 --app-dir /Applications
+EOF
+
+  exit "$exit_code"
+}
+
+error() {
+  echo "Error: $*" >&2
+}
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] Would execute: $*"
+    return 0
+  fi
+
+  "$@"
+}
+
+configure_preferences() {
+  local -a configure_args=()
+  [[ "$DRY_RUN" == "true" ]] && configure_args+=("--dry-run")
+  "$CONFIGURE_SCRIPT" "${configure_args[@]}"
+}
+
+main() {
+  local app_path marker_path marker_value archive extracted app_stage source_app
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -a | --app-dir)
+        if [[ -n "${2:-}" && ! "$2" =~ ^- ]]; then
+          APP_DIR="$2"
+          shift 2
+        else
+          error "--app-dir requires a path"
+          usage 1
+        fi
+        ;;
+      -d | --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      -h | --help)
+        usage 0
+        ;;
+      *)
+        error "Unknown option: $1"
+        usage 1
+        ;;
+    esac
+  done
+
+  if [[ "$DRY_RUN" != "true" && "$(uname -s)" != "Darwin" ]]; then
+    error "AudioPriorityBar can only be installed on macOS"
+    exit 1
+  fi
+
+  app_path="${APP_DIR}/${APP_NAME}"
+  marker_path="${APP_DIR}/.AudioPriorityBar.release"
+  marker_value="${RELEASE} ${ARCHIVE_SHA256}"
+
+  if [[ -d "$app_path" && -f "$marker_path" ]] && grep -Fqx -- "$marker_value" "$marker_path"; then
+    echo "AudioPriorityBar ${RELEASE} is already installed at ${app_path}"
+    configure_preferences
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] Would download ${RELEASE_URL}"
+    echo "[dry-run] Would verify SHA-256: ${ARCHIVE_SHA256}"
+    echo "[dry-run] Would install ${APP_NAME} to ${app_path}"
+    configure_preferences
+    return 0
+  fi
+
+  for command in curl ditto grep shasum; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+      error "Required command not found: $command"
+      exit 1
+    fi
+  done
+
+  INSTALL_TEMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$INSTALL_TEMP_DIR"' EXIT
+  archive="${INSTALL_TEMP_DIR}/${ARCHIVE}"
+  extracted="${INSTALL_TEMP_DIR}/extracted"
+  app_stage="${APP_DIR}/.${APP_NAME}.new"
+
+  curl --fail --location --retry 3 --proto '=https' --tlsv1.2 "$RELEASE_URL" --output "$archive"
+  printf '%s  %s\n' "$ARCHIVE_SHA256" "$archive" | shasum -a 256 -c --status
+  mkdir -p "$extracted"
+  ditto -x -k "$archive" "$extracted"
+
+  source_app="${extracted}/${APP_NAME}"
+  if [[ ! -d "$source_app" ]]; then
+    error "Release archive did not contain ${APP_NAME}"
+    exit 1
+  fi
+
+  mkdir -p "$APP_DIR"
+  rm -rf "$app_stage"
+  ditto "$source_app" "$app_stage"
+  rm -rf "$app_path"
+  mv "$app_stage" "$app_path"
+  printf '%s\n' "$marker_value" >"$marker_path"
+
+  echo "Installed AudioPriorityBar ${RELEASE} at ${app_path}"
+  configure_preferences
+  echo "Launch it once with: open -a '${app_path}'"
+}
+
+main "$@"

--- a/scripts/sync-private-harness-assets.sh
+++ b/scripts/sync-private-harness-assets.sh
@@ -12,7 +12,7 @@ usage() {
   cat <<'EOF'
 Usage: scripts/sync-private-harness-assets.sh [options] [--dry-run|--execute]
 
-Link selected private harness assets into the public harness views. The default
+Reconcile selected private harness assets into the public harness views. The default
 private source is the optional sibling repo ../harnesses-private. If that repo
 is absent, the script exits successfully without changing anything.
 
@@ -28,7 +28,7 @@ If a provider has load manifests, only listed skills are exposed:
 
 Options:
       --dry-run             Show planned links without changing files
-      --execute             Create missing links
+      --execute             Reconcile links
   -h, --help                Show this help message
       --private-root <path> Private harness repository path
 
@@ -126,14 +126,17 @@ link_skill() {
   local source_path="$1"
   local dest_dir="$2"
   local private_abs="$3"
-  local name
+  local name="$4"
   local dest_path
   local target
   local existing_target
 
-  name="$(basename "$source_path")"
   dest_path="$dest_dir/$name"
   target="$(relative_private_skill_target "$source_path" "$private_abs")"
+
+  if [[ -n "${DESIRED_LINKS_FILE:-}" ]]; then
+    printf '%s\n' "$dest_path" >>"$DESIRED_LINKS_FILE"
+  fi
 
   if [[ -L "$dest_path" ]]; then
     existing_target="$(readlink "$dest_path")"
@@ -197,6 +200,44 @@ skill_is_loaded_for_view() {
   return 1
 }
 
+build_loaded_skill_index() {
+  local index_file="$1"
+  local view="$2"
+  shift 2
+
+  local catalog_dir
+  local provider_dir
+  local source_path
+  local skill_name
+
+  : >"$index_file"
+
+  for catalog_dir in "$@"; do
+    [[ -d "$catalog_dir" ]] || continue
+    for provider_dir in "$catalog_dir"/*; do
+      [[ -d "$provider_dir" ]] || continue
+      [[ -d "$provider_dir/skills" ]] || continue
+
+      for source_path in "$provider_dir/skills"/*; do
+        [[ -e "$source_path" || -L "$source_path" ]] || continue
+        [[ -f "$source_path/SKILL.md" ]] || continue
+        skill_name="$(basename "$source_path")"
+        if skill_is_loaded_for_view "$provider_dir" "$skill_name" "$view"; then
+          printf '%s\t%s\n' "$skill_name" "$(basename "$provider_dir")" >>"$index_file"
+        fi
+      done
+    done
+  done
+}
+
+skill_name_has_loaded_collision() {
+  local skill_name="$1"
+
+  awk -F '\t' -v wanted="$skill_name" \
+    '$1 == wanted { providers[$2] = 1 } END { count = 0; for (provider in providers) count++; exit !(count > 1) }' \
+    "$LOADED_SKILL_INDEX_FILE"
+}
+
 link_skills_from_provider_dir() {
   local provider_dir="$1"
   local skills_dir
@@ -205,11 +246,14 @@ link_skills_from_provider_dir() {
   local view="$4"
   local source_path
   local skill_name
+  local provider_name
+  local destination_name
   local found=false
 
   skills_dir="$provider_dir/skills"
   [[ -d "$skills_dir" ]] || return 0
   mkdir -p "$dest_dir"
+  provider_name="$(basename "$provider_dir")"
 
   for source_path in "$skills_dir"/*; do
     [[ -e "$source_path" || -L "$source_path" ]] || continue
@@ -219,12 +263,82 @@ link_skills_from_provider_dir() {
       continue
     fi
     found=true
-    link_skill "$(absolute_path "$source_path")" "$dest_dir" "$private_abs"
+    destination_name="$skill_name"
+    if skill_name_has_loaded_collision "$skill_name"; then
+      destination_name="${provider_name}-${skill_name}"
+      info "namespaced collision $skill_name as $destination_name"
+    fi
+    link_skill "$(absolute_path "$source_path")" "$dest_dir" "$private_abs" "$destination_name"
   done
 
   if [[ "$found" != "true" ]]; then
     info "no loaded skills found in $skills_dir for $view"
   fi
+}
+
+resolve_link_target() {
+  local link_path="$1"
+  local target
+
+  target="$(readlink "$link_path")"
+  if [[ "$target" = /* ]]; then
+    printf '%s\n' "$target"
+    return 0
+  fi
+
+  (
+    cd "$(dirname "$link_path")"
+    cd "$(dirname "$target")"
+    printf '%s/%s\n' "$(pwd)" "$(basename "$target")"
+  )
+}
+
+prune_stale_private_links() {
+  local dest_dir="$1"
+  local private_abs="$2"
+  local dest_path
+  local source_path
+
+  [[ -d "$dest_dir" ]] || return 0
+
+  for dest_path in "$dest_dir"/*; do
+    [[ -L "$dest_path" ]] || continue
+    source_path="$(resolve_link_target "$dest_path")" || continue
+    case "$source_path" in
+      "$private_abs"/*)
+        if ! grep -Fqx "$dest_path" "$DESIRED_LINKS_FILE"; then
+          if [[ "$DRY_RUN" == "true" ]]; then
+            info "would remove stale $dest_path"
+          else
+            rm "$dest_path"
+            info "removed stale $dest_path"
+          fi
+        fi
+        ;;
+    esac
+  done
+}
+
+sync_view() {
+  local dest_dir="$1"
+  local private_abs="$2"
+  local view="$3"
+  shift 3
+
+  DESIRED_LINKS_FILE="$(mktemp "${TMPDIR:-/tmp}/sync-private-skills.XXXXXX")"
+  LOADED_SKILL_INDEX_FILE="$(mktemp "${TMPDIR:-/tmp}/sync-private-index.XXXXXX")"
+
+  build_loaded_skill_index "$LOADED_SKILL_INDEX_FILE" "$view" "$@"
+
+  local catalog_dir
+  for catalog_dir in "$@"; do
+    link_grouped_skills_from "$catalog_dir" "$dest_dir" "$private_abs" "$view"
+  done
+
+  prune_stale_private_links "$dest_dir" "$private_abs"
+  rm -f "$DESIRED_LINKS_FILE" "$LOADED_SKILL_INDEX_FILE"
+  DESIRED_LINKS_FILE=""
+  LOADED_SKILL_INDEX_FILE=""
 }
 
 link_grouped_skills_from() {
@@ -266,11 +380,9 @@ main() {
 
   private_abs="$(absolute_path "$PRIVATE_ROOT")"
 
-  link_grouped_skills_from "$private_abs" "$agents_skills" "$private_abs" "global"
-  link_grouped_skills_from "$private_abs" "$claude_skills" "$private_abs" "claude"
-  link_grouped_skills_from "$private_abs" "$codex_skills" "$private_abs" "codex"
-  link_grouped_skills_from "$private_abs/claude" "$claude_skills" "$private_abs" "claude"
-  link_grouped_skills_from "$private_abs/codex" "$codex_skills" "$private_abs" "codex"
+  sync_view "$agents_skills" "$private_abs" "global" "$private_abs"
+  sync_view "$claude_skills" "$private_abs" "claude" "$private_abs" "$private_abs/claude"
+  sync_view "$codex_skills" "$private_abs" "codex" "$private_abs" "$private_abs/codex"
 }
 
 main "$@"

--- a/stow.sh
+++ b/stow.sh
@@ -10,7 +10,6 @@ STOW_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Each directory is a GNU Stow package targeting $HOME.
 STOW_DIRS=(
-  aerospace
   agents
   aws
   bash
@@ -35,7 +34,7 @@ STOW_DIRS=(
 # Keep host-specific app and desktop configuration off the other platform.
 # In particular, a Mac sync must never touch Omarchy's Hyprland/keyd paths.
 case "$(uname -s)" in
-  Darwin) STOW_DIRS+=(audio-priority-bar) ;;
+  Darwin) STOW_DIRS+=(aerospace audio-priority-bar) ;;
   Linux) STOW_DIRS+=(omarchy) ;;
 esac
 

--- a/stow.sh
+++ b/stow.sh
@@ -40,6 +40,7 @@ esac
 
 DRY_RUN=false
 ADOPT=false
+RESTOW=false
 BACKUP_CONFLICTS=false
 BACKUP_DIR=""
 ACTIVE_BACKUP_ROOT=""
@@ -52,12 +53,13 @@ usage() {
   cat <<EOF
 Usage: $0 [options] [package ...]
 
-Symlink dotfile packages into \$HOME using GNU Stow (restow mode).
+Symlink dotfile packages into \$HOME using GNU Stow.
 With no package arguments, all packages are stowed.
 
 Options:
   -d, --dry-run   Show what would change without making changes
   -a, --adopt     Adopt pre-existing files into the repo (review with git diff!)
+  -R, --restow    Explicitly prune stale links and recreate managed links
       --backup-conflicts
                   Back up pre-existing targets, then stow the repo versions
       --backup-dir PATH
@@ -69,6 +71,7 @@ Examples:
   $0
   $0 --dry-run
   $0 zsh git
+  $0 --restow zsh
   $0 --adopt mise
   $0 --backup-conflicts zsh mise
 EOF
@@ -91,6 +94,10 @@ parse_args() {
         ;;
       -a | --adopt)
         ADOPT=true
+        shift
+        ;;
+      -R | --restow)
+        RESTOW=true
         shift
         ;;
       --backup-conflicts)
@@ -126,26 +133,30 @@ parse_args() {
 
 backup_conflicting_targets() {
   local -a dirs=("$@")
-  local dir source relative target link_target backup_target
+  local dir plan line relative target backup_target
   local backup_root=$BACKUP_DIR
+  local -a plan_opts=(
+    "--dir=$STOW_SH_DIR"
+    "--target=$HOME"
+    "--verbose=2"
+    "--stow"
+    "--adopt"
+    "--no"
+  )
 
   for dir in "${dirs[@]}"; do
     [[ -d "$STOW_SH_DIR/$dir" ]] || continue
 
-    while IFS= read -r -d '' source; do
-      relative=${source#"$STOW_SH_DIR/$dir/"}
-      target="$HOME/$relative"
-      [[ -e "$target" || -L "$target" ]] || continue
+    if ! plan=$(stow_package "$dir" "${plan_opts[@]}" 2>&1); then
+      printf '%s\n' "$plan" >&2
+      return 1
+    fi
 
-      # Relative links resolving to the source are already Stow-managed. GNU
-      # Stow rejects equivalent absolute links, so normalize those via backup.
-      if [[ "$source" -ef "$target" ]]; then
-        if [[ ! -L "$target" ]]; then
-          continue
-        fi
-        link_target=$(readlink "$target")
-        [[ "$link_target" == /* ]] || continue
-      fi
+    while IFS= read -r line; do
+      [[ "$line" == "MV: "* ]] || continue
+      relative=${line#"MV: "}
+      relative=${relative%% -> *}
+      target="$HOME/$relative"
 
       if [[ -z "$backup_root" ]]; then
         backup_root="${XDG_STATE_HOME:-$HOME/.local/state}/n-dotfiles/stow-backups/$(date +%Y%m%d-%H%M%S)-$$"
@@ -161,7 +172,7 @@ backup_conflicting_targets() {
       mv "$target" "$backup_target" || return 1
       BACKED_UP_RELATIVE_PATHS+=("$relative")
       echo "Backed up $relative to $backup_target"
-    done < <(find "$STOW_SH_DIR/$dir" \( -type f -o -type l \) -print0)
+    done <<<"$plan"
   done
 }
 
@@ -250,8 +261,12 @@ main() {
     "--dir=$STOW_SH_DIR"
     "--target=$HOME"
     "--verbose=1"
-    "-R"
   )
+  if [[ "$RESTOW" == "true" ]]; then
+    stow_opts+=("--restow")
+  else
+    stow_opts+=("--stow")
+  fi
   [[ "$ADOPT" == "true" ]] && stow_opts+=("--adopt")
   [[ "$DRY_RUN" == "true" ]] && stow_opts+=("--no")
 

--- a/stow.sh
+++ b/stow.sh
@@ -17,7 +17,6 @@ STOW_DIRS=(
   bat
   claude
   codex
-  factory
   gh
   ghostty
   git
@@ -33,14 +32,19 @@ STOW_DIRS=(
   zsh
 )
 
-# Omarchy is a Linux-only package. Keep it out of the default macOS stow set
-# so a normal dotfile sync cannot touch the Mac's Hyprland/keyd paths.
-if [[ "$(uname -s)" == "Linux" ]]; then
-  STOW_DIRS+=(omarchy)
-fi
+# Keep host-specific app and desktop configuration off the other platform.
+# In particular, a Mac sync must never touch Omarchy's Hyprland/keyd paths.
+case "$(uname -s)" in
+  Darwin) STOW_DIRS+=(audio-priority-bar) ;;
+  Linux) STOW_DIRS+=(omarchy) ;;
+esac
 
 DRY_RUN=false
 ADOPT=false
+BACKUP_CONFLICTS=false
+BACKUP_DIR=""
+ACTIVE_BACKUP_ROOT=""
+BACKED_UP_RELATIVE_PATHS=()
 LIST_MODE=false
 
 usage() {
@@ -55,6 +59,10 @@ With no package arguments, all packages are stowed.
 Options:
   -d, --dry-run   Show what would change without making changes
   -a, --adopt     Adopt pre-existing files into the repo (review with git diff!)
+      --backup-conflicts
+                  Back up pre-existing targets, then stow the repo versions
+      --backup-dir PATH
+                  Backup destination (requires --backup-conflicts)
   -l, --list      List available stow packages
   -h, --help      Show this help message
 
@@ -63,6 +71,7 @@ Examples:
   $0 --dry-run
   $0 zsh git
   $0 --adopt mise
+  $0 --backup-conflicts zsh mise
 EOF
 
   exit "$exit_code"
@@ -85,6 +94,18 @@ parse_args() {
         ADOPT=true
         shift
         ;;
+      --backup-conflicts)
+        BACKUP_CONFLICTS=true
+        shift
+        ;;
+      --backup-dir)
+        if [[ $# -lt 2 || -z "$2" ]]; then
+          error "--backup-dir requires a path"
+          usage 1
+        fi
+        BACKUP_DIR=$2
+        shift 2
+        ;;
       -l | --list)
         LIST_MODE=true
         shift
@@ -104,6 +125,75 @@ parse_args() {
   done
 }
 
+backup_conflicting_targets() {
+  local -a dirs=("$@")
+  local dir source relative target link_target backup_target
+  local backup_root=$BACKUP_DIR
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "$STOW_SH_DIR/$dir" ]] || continue
+
+    while IFS= read -r -d '' source; do
+      relative=${source#"$STOW_SH_DIR/$dir/"}
+      target="$HOME/$relative"
+      [[ -e "$target" || -L "$target" ]] || continue
+
+      # Relative links resolving to the source are already Stow-managed. GNU
+      # Stow rejects equivalent absolute links, so normalize those via backup.
+      if [[ "$source" -ef "$target" ]]; then
+        if [[ ! -L "$target" ]]; then
+          continue
+        fi
+        link_target=$(readlink "$target")
+        [[ "$link_target" == /* ]] || continue
+      fi
+
+      if [[ -z "$backup_root" ]]; then
+        backup_root="${XDG_STATE_HOME:-$HOME/.local/state}/n-dotfiles/stow-backups/$(date +%Y%m%d-%H%M%S)-$$"
+      fi
+      ACTIVE_BACKUP_ROOT=$backup_root
+      backup_target="$backup_root/$relative"
+      if [[ -e "$backup_target" || -L "$backup_target" ]]; then
+        error "Backup target already exists: $backup_target"
+        return 1
+      fi
+
+      mkdir -p "$(dirname "$backup_target")" || return 1
+      mv "$target" "$backup_target" || return 1
+      BACKED_UP_RELATIVE_PATHS+=("$relative")
+      echo "Backed up $relative to $backup_target"
+    done < <(find "$STOW_SH_DIR/$dir" \( -type f -o -type l \) -print0)
+  done
+}
+
+restore_staged_backups() {
+  local index relative target backup_path
+
+  for ((index = ${#BACKED_UP_RELATIVE_PATHS[@]} - 1; index >= 0; index--)); do
+    relative=${BACKED_UP_RELATIVE_PATHS[$index]}
+    target="$HOME/$relative"
+    backup_path="$ACTIVE_BACKUP_ROOT/$relative"
+    if [[ -e "$target" || -L "$target" ]]; then
+      error "Cannot restore backup because target now exists: $target"
+      continue
+    fi
+    mkdir -p "$(dirname "$target")"
+    mv "$backup_path" "$target"
+    echo "Restored $target after failed preflight"
+  done
+}
+
+stow_package() {
+  local dir=$1
+  shift
+  local -a options=("$@")
+
+  # Keep Omarchy's shared ~/.config tree as real directories. Without this,
+  # Stow can fold a fresh ~/.config into a single package symlink.
+  [[ "$dir" == "omarchy" ]] && options+=("--no-folding")
+  stow "${options[@]}" "$dir"
+}
+
 validate_requested_dirs() {
   local dir known
   for dir in "${REQUESTED_DIRS[@]}"; do
@@ -121,6 +211,19 @@ validate_requested_dirs() {
 main() {
   parse_args "$@"
 
+  if [[ "$ADOPT" == "true" && "$BACKUP_CONFLICTS" == "true" ]]; then
+    error "--adopt and --backup-conflicts cannot be used together"
+    exit 1
+  fi
+  if [[ "$DRY_RUN" == "true" && "$BACKUP_CONFLICTS" == "true" ]]; then
+    error "--dry-run and --backup-conflicts cannot be used together"
+    exit 1
+  fi
+  if [[ -n "$BACKUP_DIR" && "$BACKUP_CONFLICTS" != "true" ]]; then
+    error "--backup-dir requires --backup-conflicts"
+    exit 1
+  fi
+
   if [[ "$LIST_MODE" == "true" ]]; then
     printf '%s\n' "${STOW_DIRS[@]}"
     exit 0
@@ -137,6 +240,13 @@ main() {
     dirs=("${REQUESTED_DIRS[@]}")
   fi
 
+  if [[ "$BACKUP_CONFLICTS" == "true" ]]; then
+    if ! backup_conflicting_targets "${dirs[@]}"; then
+      restore_staged_backups
+      return 1
+    fi
+  fi
+
   local -a stow_opts=(
     "--dir=$STOW_SH_DIR"
     "--target=$HOME"
@@ -146,20 +256,36 @@ main() {
   [[ "$ADOPT" == "true" ]] && stow_opts+=("--adopt")
   [[ "$DRY_RUN" == "true" ]] && stow_opts+=("--no")
 
-  local dir failed=0
-  local -a package_stow_opts
+  local dir failed=0 preflight_output
+  local -a preflight_opts
+
+  # GNU Stow validates one invocation at a time. Preflight every requested
+  # package before applying any of them so a late conflict cannot leave HOME
+  # partially restowed.
+  if [[ "$DRY_RUN" != "true" ]]; then
+    for dir in "${dirs[@]}"; do
+      [[ -d "$STOW_SH_DIR/$dir" ]] || continue
+      preflight_opts=("${stow_opts[@]}" "--no")
+
+      if ! preflight_output=$(stow_package "$dir" "${preflight_opts[@]}" 2>&1); then
+        printf '%s\n' "$preflight_output" >&2
+        error "Failed to preflight $dir"
+        failed=1
+      fi
+    done
+    if [[ "$failed" -ne 0 ]]; then
+      [[ "$BACKUP_CONFLICTS" == "true" ]] && restore_staged_backups
+      return "$failed"
+    fi
+  fi
+
   for dir in "${dirs[@]}"; do
     if [[ ! -d "$STOW_SH_DIR/$dir" ]]; then
       echo "Skipping missing package: $dir"
       continue
     fi
 
-    package_stow_opts=("${stow_opts[@]}")
-    # Keep Omarchy's shared ~/.config tree as real directories. Without this,
-    # Stow can fold a fresh ~/.config into a single package symlink.
-    [[ "$dir" == "omarchy" ]] && package_stow_opts+=("--no-folding")
-
-    if stow "${package_stow_opts[@]}" "$dir"; then
+    if stow_package "$dir" "${stow_opts[@]}"; then
       echo "Stowed $dir"
     else
       error "Failed to stow $dir"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -137,8 +137,11 @@ _cache_init() {
 
 _dedupe_path() {
   typeset -gaU path
+  local arkade_bin="$HOME/.arkade/bin"
   path=(${(s/:/)PATH})
   path=(${(M)path:#?*})
+  path=("${(@)path:#$arkade_bin}")
+  [[ -d "$arkade_bin" ]] && path+=("$arkade_bin")
   export PATH
 }
 


### PR DESCRIPTION
## Summary

- make macOS installation repeatable without unexpectedly upgrading or reinstalling existing apps, and apply narrowly scoped Homebrew tap trust
- install a pinned AudioPriorityBar release and keep its managed device preferences in the Stow tree
- remove Gemini CLI, Claude, Factory, and beads from managed installation while retaining Arkade only as a final PATH fallback behind mise
- preserve unmanaged Stow conflicts through recoverable backups and keep the Omarchy bootstrap compatible with macOS Bash 3
- repair platform and 1Password fixtures, and make the pre-push lint gate ignore untracked vendored content

## Verification

- `make install`
- `brew doctor`
- `lefthook validate`
- `lefthook run pre-push`
  - `make lint`
  - `make test` (all 167 cases passed; 4 intentional skips)
- live login shell resolves `gh` from mise, with `~/.arkade/bin` last in PATH
